### PR TITLE
feat: add GitHub session mode and cancellable load queue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches:
-      - master
-      - main
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:
@@ -18,7 +16,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     steps:
@@ -30,15 +27,6 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
-      - name: Type check
-        run: bun run typecheck
-
-      - name: Lint
-        run: bun run lint
-
-      - name: Run unit tests
-        run: bun run test:unit
 
       - name: Build
         run: bun run build
@@ -53,7 +41,6 @@ jobs:
         with:
           path: './dist'
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,9 @@ git remote add upstream https://github.com/michael-farah/repo2txt-extension.git
 # Install dependencies
 bun install
 
+# Set up git hooks (required for local CI)
+git config core.hooksPath .githooks
+
 # Copy test configuration template
 cp tests/test-config.example.ts tests/test-config.ts
 # Add your GitHub token to test-config.ts (optional, for E2E tests)
@@ -67,6 +70,69 @@ bun run format:check     # Check formatting
 # CI Pipeline (runs all checks)
 bun run ci               # typecheck + lint + test:unit
 ```
+
+## 🔧 Local CI with Act
+
+This project supports running CI checks locally using [nektos/act](https://github.com/nektos/act), which runs GitHub Actions workflows in Docker containers. This provides fast feedback without pushing to GitHub.
+
+### Prerequisites
+
+1. **Install act**: `brew install act` or see the [installation guide](https://nektosact.com/installation/index.html)
+2. **Docker must be running** — act uses Docker to run workflow containers
+
+### Running CI Locally
+
+```bash
+# Run the full CI workflow (typecheck + lint + test + build)
+act -W .github/workflows/ci.yml
+
+# Run only the ci job
+act -W .github/workflows/ci.yml -j ci
+
+# Dry run (list steps without executing)
+act -W .github/workflows/ci.yml -n
+
+# List all available jobs
+act -l
+
+# Skip pulling Docker images on subsequent runs
+act -W .github/workflows/ci.yml --pull=false
+```
+
+### Pre-Commit Hook
+
+A pre-commit hook is configured to automatically run CI checks via `act` before each commit. This ensures code quality is validated locally before pushing.
+
+```bash
+# Normal commit — hook runs CI automatically
+git commit -m "feat: new feature"
+
+# Skip the hook (not recommended, use for WIP commits only)
+git commit --no-verify -m "wip: work in progress"
+```
+
+### Secrets Configuration
+
+Copy the secrets template and fill in values if needed:
+
+```bash
+cp .secrets.example .secrets
+# Edit .secrets with your values (optional for CI checks)
+```
+
+The `.secrets` file is git-ignored and read by act via `.actrc`.
+
+### Workflow Structure
+
+- **`ci.yml`** — Act-compatible CI workflow (typecheck, lint, test, build). Only triggers via `workflow_dispatch` (run locally with `act`, not on GitHub push).
+- **`deploy.yml`** — GitHub Pages deployment only. Runs on push to main/master. Not run locally (uses GitHub-specific Pages actions).
+
+### Troubleshooting
+
+- **Image pull errors**: Run `act --pull` first to download runner images
+- **Permission denied on hook**: `chmod +x .githooks/pre-commit`
+- **Slow first run**: Act downloads Docker images (~2GB) on first use
+- **Docker not running**: Start Docker Desktop or the Docker daemon
 
 ## 🏗️ Architecture Overview
 
@@ -389,9 +455,12 @@ class ErrorBoundary extends Component {
 
 ```
 repo2txt/
+├── .githooks/
+│   └── pre-commit            # Runs act CI before each commit
 ├── .github/
 │   └── workflows/
-│       └── deploy.yml           # GitHub Actions CI/CD
+│       ├── ci.yml              # CI checks (act-compatible, local only)
+│       └── deploy.yml          # GitHub Pages deployment
 │
 ├── src/
 │   ├── features/                # Feature modules (domain-driven)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ bun run build
 
 Then load the `dist/` folder as an unpacked extension in `chrome://extensions`.
 
+### For Distribution
+
+```bash
+bun run build:crx
+```
+
+This creates `release/repo2txt-v{version}.zip` ready for Chrome Web Store upload.
+
 ### Development
 
 ```bash
@@ -123,6 +131,28 @@ bun install
 bun run test:unit
 bun run dev
 ```
+
+## Browser Support
+
+**Chrome Only** — This extension uses Chrome Manifest V3 APIs including service workers and `chrome.storage.local`.
+
+### Future Support
+
+- **Firefox**: Would require `browser-polyfill` for API compatibility and MV3 adjustments
+- **Safari**: Requires Xcode project generation and App Store distribution
+- **Edge**: Should work as-is since Edge supports Chrome extensions
+
+Contributions for cross-browser support are welcome!
+
+## Future Providers
+
+We're considering support for additional Git hosting platforms:
+
+- **GitLab**: API authentication, self-hosted instances, different rate limits
+- **Bitbucket**: API authentication, different repository structure
+- **Gitea/Forgejo**: Self-hosted instances, API versioning
+
+To contribute a new provider, extend `BaseProvider` and implement `fetchTree`, `fetchFile`, `validateUrl`, and `parseUrl`. See `src/features/github/GitHubProvider.ts` for reference.
 
 ## 📝 License
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,8 @@
         "clsx": "^2.1.1",
         "gpt-tokenizer": "^3.4.0",
         "jszip": "^3.10.1",
+        "playwright": "^1.59.1",
+        "puppeteer": "^24.40.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwind-merge": "^3.4.1",
@@ -208,6 +210,8 @@
 
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.0", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg=="],
@@ -304,6 +308,8 @@
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
+    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
@@ -343,6 +349,8 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.58.2", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.58.2", "@typescript-eslint/type-utils": "8.58.2", "@typescript-eslint/utils": "8.58.2", "@typescript-eslint/visitor-keys": "8.58.2", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.58.2", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw=="],
 
@@ -386,6 +394,8 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -404,13 +414,31 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
+
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
 
     "autoprefixer": ["autoprefixer@10.5.0", "", { "dependencies": { "browserslist": "^4.28.2", "caniuse-lite": "^1.0.30001787", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong=="],
 
+    "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
+
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
+
+    "bare-fs": ["bare-fs@4.7.1", "", { "dependencies": { "bare-events": "^2.5.4", "bare-path": "^3.0.0", "bare-stream": "^2.6.4", "bare-url": "^2.2.2", "fast-fifo": "^1.3.2" }, "peerDependencies": { "bare-buffer": "*" }, "optionalPeers": ["bare-buffer"] }, "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw=="],
+
+    "bare-os": ["bare-os@3.8.7", "", {}, "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w=="],
+
+    "bare-path": ["bare-path@3.0.0", "", { "dependencies": { "bare-os": "^3.0.1" } }, "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw=="],
+
+    "bare-stream": ["bare-stream@2.13.0", "", { "dependencies": { "streamx": "^2.25.0", "teex": "^1.0.1" }, "peerDependencies": { "bare-abort-controller": "*", "bare-buffer": "*", "bare-events": "*" }, "optionalPeers": ["bare-abort-controller", "bare-buffer", "bare-events"] }, "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA=="],
+
+    "bare-url": ["bare-url@2.4.0", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.18", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A=="],
+
+    "basic-ftp": ["basic-ftp@5.2.2", "", {}, "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
@@ -419,6 +447,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -431,6 +461,8 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "chromium-bidi": ["chromium-bidi@14.0.0", "", { "dependencies": { "mitt": "^3.0.1", "zod": "^3.24.1" }, "peerDependencies": { "devtools-protocol": "*" } }, "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -452,6 +484,8 @@
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
+    "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
@@ -460,13 +494,19 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devtools-protocol": ["devtools-protocol@0.0.1581282", "", {}, "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ=="],
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
@@ -478,7 +518,13 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
@@ -489,6 +535,8 @@
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
+
+    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
     "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
 
@@ -502,6 +550,8 @@
 
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
@@ -512,9 +562,15 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -523,6 +579,8 @@
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -546,6 +604,10 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
@@ -568,6 +630,10 @@
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
@@ -579,6 +645,10 @@
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -613,6 +683,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -678,6 +750,8 @@
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msw": ["msw@2.13.3", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w=="],
@@ -690,6 +764,8 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
     "node-releases": ["node-releases@2.0.37", "", {}, "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
@@ -700,6 +776,8 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
@@ -708,9 +786,15 @@
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
+
+    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
+
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -721,6 +805,8 @@
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -756,7 +842,19 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
+    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "puppeteer": ["puppeteer@24.40.0", "", { "dependencies": { "@puppeteer/browsers": "2.13.0", "chromium-bidi": "14.0.0", "cosmiconfig": "^9.0.0", "devtools-protocol": "0.0.1581282", "puppeteer-core": "24.40.0", "typed-query-selector": "^2.12.1" }, "bin": { "puppeteer": "lib/cjs/puppeteer/node/cli.js" } }, "sha512-IxQbDq93XHVVLWHrAkFP7F7iHvb9o0mgfsSIMlhHb+JM+JjM1V4v4MNSQfcRWJopx9dsNOr9adYv0U5fm9BJBQ=="],
+
+    "puppeteer-core": ["puppeteer-core@24.40.0", "", { "dependencies": { "@puppeteer/browsers": "2.13.0", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1581282", "typed-query-selector": "^2.12.1", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.19.0" } }, "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -808,6 +906,14 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -815,6 +921,8 @@
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
+
+    "streamx": ["streamx@2.25.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
@@ -839,6 +947,14 @@
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
+
+    "tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
+
+    "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
+
+    "text-decoder": ["text-decoder@1.2.7", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -870,6 +986,8 @@
 
     "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
+    "typed-query-selector": ["typed-query-selector@2.12.1", "", {}, "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "typescript-eslint": ["typescript-eslint@8.58.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.58.2", "@typescript-eslint/parser": "8.58.2", "@typescript-eslint/typescript-estree": "8.58.2", "@typescript-eslint/utils": "8.58.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ=="],
@@ -888,6 +1006,8 @@
 
     "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
 
+    "webdriver-bidi-protocol": ["webdriver-bidi-protocol@0.4.1", "", {}, "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="],
+
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -898,6 +1018,8 @@
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -907,6 +1029,8 @@
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
@@ -924,6 +1048,8 @@
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "@puppeteer/browsers/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -940,6 +1066,8 @@
 
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -951,6 +1079,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/package.json
+++ b/package.json
@@ -27,13 +27,17 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "ci": "bun run typecheck && bun run lint && bun run test:unit"
+    "ci": "bun run typecheck && bun run lint && bun run test:unit",
+    "build:crx": "bun run build && bun run scripts/package-crx.ts",
+    "build:zip": "bun run build && cd dist && zip -r ../repo2txt-extension.zip ."
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.18",
     "clsx": "^2.1.1",
     "gpt-tokenizer": "^3.4.0",
     "jszip": "^3.10.1",
+    "playwright": "^1.59.1",
+    "puppeteer": "^24.40.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tailwind-merge": "^3.4.1",

--- a/scripts/package-crx.ts
+++ b/scripts/package-crx.ts
@@ -1,0 +1,32 @@
+import { execSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const distDir = resolve(import.meta.dir, '../dist');
+const releaseDir = resolve(import.meta.dir, '../release');
+const manifestPath = resolve(distDir, 'manifest.json');
+
+// Ensure dist exists
+if (!existsSync(distDir)) {
+  console.error('dist/ directory not found. Run `bun run build` first.');
+  process.exit(1);
+}
+
+// Read version from manifest
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+const version = manifest.version;
+
+// Create release directory
+if (!existsSync(releaseDir)) {
+  mkdirSync(releaseDir, { recursive: true });
+}
+
+console.log(`Packaging repo2txt v${version}...`);
+
+// Create zip for Chrome Web Store
+const zipName = `repo2txt-v${version}.zip`;
+execSync(`cd ${distDir} && zip -r ${resolve(releaseDir, zipName)} . -x "*.map"`);
+
+console.log(`Created: release/${zipName}`);
+console.log('\nUpload this zip to Chrome Web Store Developer Dashboard.');
+console.log('For local testing, load the dist/ folder as an unpacked extension.');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,8 @@ import { Formatter } from '@/lib/formatter';
 import { buildTree, extractDirectories } from '@/lib/tree-builder';
 import { extractGitHubRepoName, extractLocalName } from '@/lib/utils/repoName';
 import { useStore } from '@/store';
-import type {
+import { useLoadQueue } from '@/hooks/useLoadQueue';
+  import type {
   FileNode,
   FileContent,
   ExtensionFilter as ExtensionFilterType,
@@ -19,7 +20,6 @@ import type {
   FileSystemDirectoryHandle,
 } from '@/types';
 import type { IProvider } from '@/lib/providers/types';
-
 interface ProcessingState {
   repoUrl: string;
   status: 'loading' | 'loaded' | 'generating';
@@ -52,7 +52,6 @@ function App() {
   } = useStore((state) => state);
 
   // Local state
-  const [isLoading, setIsLoading] = useState(false);
   const [showExcluded, setShowExcluded] = useState(false);
   const [output, setOutput] = useState<FormattedOutput | null>(null);
   const [currentProvider, setCurrentProvider] = useState<IProvider | null>(null);
@@ -64,10 +63,13 @@ function App() {
   } | null>(null);
   const [initialUrl, setInitialUrl] = useState<string | undefined>(undefined);
   const [autoSubmitUrl, setAutoSubmitUrl] = useState<string | undefined>(undefined);
+  const [githubTabId, setGithubTabId] = useState<number | null>(null);
   const shouldAutoExpandRoot = useRef(false);
   const outputRef = useRef<HTMLDivElement>(null);
   const hasInitialized = useRef(false);
 
+  // Use the load queue hook for cancellable loading
+  const { loading: isLoading, start: startLoad, cancel: cancelLoad } = useLoadQueue();
   // Initialization: check processing state, pending URL, and auto-detect current tab
   useEffect(() => {
     if (hasInitialized.current) return;
@@ -86,24 +88,31 @@ function App() {
           const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
           if (tab?.url && provider.validateUrl(tab.url)) {
             currentTabUrl = tab.url;
+            if (tab.id !== undefined) {
+              setGithubTabId(tab.id);
+            }
           }
         }
 
         // 1. Check for existing processing state
         const stateResult = await chrome.storage.session.get('processingState');
         const processingState = stateResult.processingState as ProcessingState | undefined;
-        
+
         if (processingState?.repoUrl) {
           // If we're on a NEW GitHub page and previous processing finished, discard old state
-          if (currentTabUrl && currentTabUrl !== processingState.repoUrl && processingState.status === 'loaded') {
+          if (
+            currentTabUrl &&
+            currentTabUrl !== processingState.repoUrl &&
+            processingState.status === 'loaded'
+          ) {
             await chrome.storage.session.remove('processingState');
-            
+
             // Clear store state for the new repo
             useStore.getState().setNodes([]);
             useStore.getState().setTree([]);
             useStore.getState().setGitignorePatterns([]);
             setOutput(null);
-            
+
             setInitialUrl(currentTabUrl);
             // We don't auto-submit the new URL, let the user click Generate
             return;
@@ -142,7 +151,11 @@ function App() {
 
     const provider = new GitHubProvider();
 
-    const handleTabUpdate = async (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => {
+    const handleTabUpdate = async (
+      tabId: number,
+      changeInfo: chrome.tabs.TabChangeInfo,
+      tab: chrome.tabs.Tab
+    ) => {
       if (changeInfo.url && provider.validateUrl(changeInfo.url) && !isLoading) {
         // Only update if the tab is the active tab in the current window
         if (tab.active) {
@@ -150,6 +163,7 @@ function App() {
             const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
             if (activeTab && activeTab.id === tabId) {
               setInitialUrl(changeInfo.url);
+              setGithubTabId(tabId);
             }
           } catch {
             // Ignore errors
@@ -162,8 +176,17 @@ function App() {
       try {
         // Only update if the activated tab is in the current window
         const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
-        if (activeTab && activeTab.id === activeInfo.tabId && activeTab.url && provider.validateUrl(activeTab.url) && !isLoading) {
+        if (
+          activeTab &&
+          activeTab.id === activeInfo.tabId &&
+          activeTab.url &&
+          provider.validateUrl(activeTab.url) &&
+          !isLoading
+        ) {
           setInitialUrl(activeTab.url);
+          if (activeTab.id !== undefined) {
+            setGithubTabId(activeTab.id);
+          }
         }
       } catch {
         // Tab may have been closed
@@ -227,6 +250,7 @@ function App() {
     setShowExcluded(false);
     setInitialUrl(undefined);
     setAutoSubmitUrl(undefined);
+    setGithubTabId(null);
 
     if (typeof chrome !== 'undefined' && chrome.storage?.session) {
       chrome.storage.session.remove('processingState');
@@ -240,6 +264,7 @@ function App() {
     setShowExcluded,
     setInitialUrl,
     setAutoSubmitUrl,
+    setGithubTabId,
   ]);
 
   // Auto-expand root directories for local directory uploads
@@ -259,7 +284,6 @@ function App() {
   const loadFiles = useCallback(
     async (provider: IProvider, url: string) => {
       try {
-        setIsLoading(true);
         setCurrentProvider(provider);
         setOutput(null);
 
@@ -269,8 +293,16 @@ function App() {
           });
         }
 
-        // Fetch file tree
-        const fetchedNodes = await provider.fetchTree(url);
+        // Use the queue-based loader with abort support
+        const fetchedNodes = await startLoad(provider, url);
+
+        // If null was returned, the load was cancelled
+        if (fetchedNodes === null) {
+          if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+            chrome.storage.session.remove('processingState');
+          }
+          return;
+        }
 
         if (typeof chrome !== 'undefined' && chrome.storage?.session) {
           chrome.storage.session.set({
@@ -282,6 +314,14 @@ function App() {
         setNodes(fetchedNodes);
       } catch (err) {
         console.error('Failed to load files:', err);
+
+        // Don't show error dialog for aborted requests
+        if (err instanceof Error && err.name === 'AbortError') {
+          if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+            chrome.storage.session.remove('processingState');
+          }
+          return;
+        }
 
         if (typeof chrome !== 'undefined' && chrome.storage?.session) {
           chrome.storage.session.remove('processingState');
@@ -298,13 +338,10 @@ function App() {
             message: err instanceof Error ? err.message : 'Failed to load files. Please try again.',
           });
         }
-      } finally {
-        setIsLoading(false);
       }
     },
-    [setNodes]
+    [setNodes, startLoad]
   );
-
   // Handle GitHub submission
   const handleGitHubSubmit = useCallback(
     async (url: string) => {
@@ -316,11 +353,13 @@ function App() {
       const { pat } = useStore.getState();
       if (pat) {
         provider.setCredentials({ token: pat });
+      } else {
+        provider.setSessionMode(true);
       }
 
       await loadFiles(provider, url);
     },
-    [loadFiles, setProviderType, setRepoUrl]
+    [loadFiles, setProviderType, setRepoUrl, githubTabId]
   );
 
   // Handle local directory submission
@@ -422,6 +461,9 @@ function App() {
   const handleGenerateOutput = useCallback(async () => {
     if (!currentProvider) return;
 
+    // Create an AbortController for the generation
+    const abortController = new AbortController();
+
     try {
       setIsLoading(true);
 
@@ -430,7 +472,7 @@ function App() {
       if (selectedNodes.length === 0) {
         setError({
           message:
-            'No files selected.\n\nPlease select at least one file to generate output. You can:\n• Click the checkbox next to "File Tree" to select all files\n• Expand directories and select individual files\n• Use the Extension Filter to select files by type',
+            'No files selected.\\n\\nPlease select at least one file to generate output. You can:\\n• Click the checkbox next to "File Tree" to select all files\\n• Expand directories and select individual files\\n• Use the Extension Filter to select files by type',
         });
         return;
       }
@@ -446,9 +488,9 @@ function App() {
         });
       }
 
-      // Fetch file contents
+      // Fetch file contents with abort support
       const fileContents: FileContent[] = [];
-      for await (const content of currentProvider.fetchMultiple(selectedNodes)) {
+      for await (const content of currentProvider.fetchMultiple(selectedNodes, abortController.signal)) {
         fileContents.push(content);
       }
 
@@ -494,6 +536,11 @@ function App() {
       }, 100);
     } catch (err) {
       console.error('Failed to generate output:', err);
+
+      // Don't show error dialog for aborted requests
+      if (err instanceof Error && err.name === 'AbortError') {
+        return;
+      }
 
       if (err instanceof ProviderError) {
         setError({
@@ -596,31 +643,40 @@ function App() {
                 onToggleExcluded={setShowExcluded}
               />
 
-              {/* File Tree */}
-              <div className="space-y-2" data-testid="file-tree-section">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <label className="flex items-center gap-1.5 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={globalCheckboxState === 'checked'}
-                        ref={(input) => {
-                          if (input) {
-                            input.indeterminate = globalCheckboxState === 'indeterminate';
-                          }
-                        }}
-                        onChange={handleGlobalToggle}
-                        className="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
-                        aria-label="Select all files"
-                      />
-                      <h2
-                        className="text-sm font-semibold text-gray-900 dark:text-gray-100"
-                        data-testid="file-tree-heading"
-                      >
-                        File Tree
-                      </h2>
-                    </label>
-                  </div>
+            {/* File Tree */}
+            <div className="space-y-2" data-testid="file-tree-section">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <label className="flex items-center gap-1.5 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={globalCheckboxState === 'checked'}
+                      ref={(input) => {
+                        if (input) {
+                          input.indeterminate = globalCheckboxState === 'indeterminate';
+                        }
+                      }}
+                      onChange={handleGlobalToggle}
+                      className="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+                      aria-label="Select all files"
+                    />
+                    <h2
+                      className="text-sm font-semibold text-gray-900 dark:text-gray-100"
+                      data-testid="file-tree-heading"
+                    >
+                      File Tree
+                    </h2>
+                  </label>
+                </div>
+                <div className="flex items-center gap-2">
+                  {isLoading && (
+                    <button
+                      onClick={cancelLoad}
+                      className="inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-200 text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 h-8 px-3 text-xs touch-manipulation"
+                    >
+                      Cancel
+                    </button>
+                  )}
                   <button
                     onClick={handleGenerateOutput}
                     disabled={isLoading}
@@ -643,18 +699,18 @@ function App() {
                     <span>Generate</span>
                   </button>
                 </div>
-
-                <FileTree
-                  nodes={tree}
-                  onToggle={toggleExpanded}
-                  onSelect={toggleSelection}
-                  showExcluded={showExcluded}
-                  maxHeight={300}
-                />
               </div>
-            </section>
-          )}
 
+              <FileTree
+                nodes={tree}
+                onToggle={toggleExpanded}
+                onSelect={toggleSelection}
+                showExcluded={showExcluded}
+                maxHeight={300}
+              />
+            </div>
+          </section>
+        )}
           {/* Output */}
           {(output || isLoading) && (
             <section ref={outputRef}>

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -9,7 +9,8 @@ interface ProcessingState {
   timestamp: number;
 }
 
-// Message handlers
+// Track pending requests for cancellation
+const pendingRequests = new Map<string, AbortController>();
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   // Handle OPEN_POPUP_WITH_REPO - store processing state and set badge
   if (message.type === 'OPEN_POPUP_WITH_REPO' && message.repoUrl) {
@@ -98,6 +99,101 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
     return true;
   }
+
+/**
+ * Handle GITHUB_WEB_FETCH - fetch github.com pages from the service worker.
+ * Chrome MV3 service workers can use fetch() with credentials: 'include' when
+ * the extension has host_permissions for the target domain. This allows
+ * fetching GitHub pages with the user's _gh_sess cookie included.
+ */
+if (message.type === 'GITHUB_WEB_FETCH' && message.url) {
+  const { url, requestId } = message as { url: string; requestId?: string };
+
+  // Security: validate URL targets github.com or raw.githubusercontent.com (prevent SSRF)
+  // Using URL parsing to prevent bypasses like github.com.evil.com or github.com@evil.com
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    sendResponse({
+      success: false,
+      status: 0,
+      html: '',
+      error: 'Invalid URL: must be a github.com or raw.githubusercontent.com URL',
+    });
+    return true;
+  }
+
+  const allowedHosts = ['github.com', 'raw.githubusercontent.com'];
+  if (parsedUrl.protocol !== 'https:' || !allowedHosts.includes(parsedUrl.hostname)) {
+    sendResponse({
+      success: false,
+      status: 0,
+      html: '',
+      error: 'Invalid URL: must be a github.com or raw.githubusercontent.com URL',
+    });
+    return true;
+  }
+
+  console.debug(`[repo2txt] GITHUB_WEB_FETCH: ${url}`);
+
+  // Create AbortController for this request
+  const controller = new AbortController();
+  if (requestId) {
+    pendingRequests.set(requestId, controller);
+  }
+
+  fetch(url, { credentials: 'include', signal: controller.signal })
+    .then(async (response) => {
+      const html = await response.text();
+      console.debug(`[repo2txt] GITHUB_WEB_FETCH: ${url} → ${response.status} (${html.length} bytes)`);
+      sendResponse({
+        success: response.ok,
+        status: response.status,
+        html,
+      });
+    })
+    .catch((error: Error) => {
+      if (error.name === 'AbortError') {
+        console.debug(`[repo2txt] GITHUB_WEB_FETCH: ${url} → aborted`);
+        sendResponse({
+          success: false,
+          status: 0,
+          html: '',
+          error: 'Request aborted',
+        });
+      } else {
+        console.error('repo2txt: Failed to fetch GitHub page:', error);
+        sendResponse({
+          success: false,
+          status: 0,
+          html: '',
+          error: error.message,
+        });
+      }
+    })
+    .finally(() => {
+      // Clean up the pending request
+      if (requestId) {
+        pendingRequests.delete(requestId);
+      }
+    });
+
+  return true;
+}
+
+// Handle ABORT_GITHUB_FETCH - cancel a pending request
+if (message.type === 'ABORT_GITHUB_FETCH' && message.requestId) {
+  const controller = pendingRequests.get(message.requestId);
+  if (controller) {
+    controller.abort();
+    pendingRequests.delete(message.requestId);
+    sendResponse({ success: true });
+  } else {
+    sendResponse({ success: false, error: 'Request not found' });
+  }
+  return true;
+}
 });
 
 // Listen for session storage changes to manage badge
@@ -120,9 +216,10 @@ chrome.storage.session.onChanged.addListener((changes) => {
   }
 
   // Status updated — clear badge when loading is done
-  if (newValue?.status === 'loaded') {
+  const newState = newValue as ProcessingState | undefined;
+  if (newState?.status === 'loaded') {
     chrome.action.setBadgeText({ text: '' });
-  } else if (newValue?.status === 'generating') {
+  } else if (newState?.status === 'generating') {
     chrome.action.setBadgeText({ text: '1' });
     chrome.action.setBadgeBackgroundColor({ color: '#4F46E5' });
   }

--- a/src/content-scripts/github.ts
+++ b/src/content-scripts/github.ts
@@ -238,11 +238,10 @@ function injectButton(): void {
       return;
     }
 
-    // Construct repo URL
-    let repoUrl = `https://github.com/${repoInfo.owner}/${repoInfo.repo}`;
-    if (repoInfo.branch) {
-      repoUrl += `/tree/${repoInfo.branch}`;
-    }
+    // Use the current page URL directly — it already contains the full branch name
+    // (including slashes like feature/auth/login) and any subdirectory path.
+    // Reconstructing from pathParts would lose segments after the first slash.
+    const repoUrl = window.location.href;
 
     // Send message to background script to open popup
     if (chrome.runtime && chrome.runtime.sendMessage) {

--- a/src/features/github/GitHubProvider.ts
+++ b/src/features/github/GitHubProvider.ts
@@ -1,6 +1,7 @@
 /**
  * GitHub provider implementation
  * Supports public and private repositories with personal access tokens
+ * Also supports session mode for authenticated GitHub API calls using browser session cookies
  */
 
 import { BaseProvider } from '@/lib/providers/BaseProvider';
@@ -16,8 +17,486 @@ interface GitHubReferences {
 
 export class GitHubProvider extends BaseProvider {
   private static readonly API_BASE = 'https://api.github.com';
+  private static readonly WEB_BASE = 'https://github.com';
   private static readonly URL_PATTERN =
     /^https:\/\/github\.com\/([^/]+)\/([^/]+)(?:\/tree\/(.+))?$/;
+
+  /** Whether to use browser session cookies for authentication */
+  private sessionMode: boolean = false;
+
+  /** Cached default branch for session mode */
+  private sessionDefaultBranch: string | null = null;
+
+  /**
+   * Enable or disable session mode for authenticated GitHub access
+   * When enabled, requests use github.com web endpoints with browser session cookies
+   */
+  setSessionMode(enabled: boolean): void {
+    this.sessionMode = enabled;
+    this.sessionDefaultBranch = null;
+  }
+
+  /**
+   * Fetch a URL using the background script's session-authenticated fetch
+   * This sends GITHUB_WEB_FETCH messages that use github.com web endpoints
+   */
+  /**
+ * Fetch a URL using the background script's session-authenticated fetch
+ * This sends GITHUB_WEB_FETCH messages that use github.com web endpoints
+ */
+private async sessionFetch(url: string, signal?: AbortSignal): Promise<string> {
+  let response: { success: boolean; status: number; html: string; error?: string } | undefined;
+
+  // Check if aborted before starting
+  if (signal?.aborted) {
+    throw new Error('AbortError');
+  }
+
+  try {
+    response = await chrome.runtime.sendMessage({
+      type: 'GITHUB_WEB_FETCH',
+      url,
+      requestId: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    });
+  } catch {
+    throw new ProviderError(
+      'Extension context unavailable',
+      ErrorCode.PROVIDER_ERROR,
+      'Could not communicate with the extension background script. Please reload the extension popup and try again.'
+    );
+  }
+
+  if (!response) {
+    throw new ProviderError(
+      'Extension context unavailable',
+      ErrorCode.PROVIDER_ERROR,
+      'Could not communicate with the extension background script. Please reload the extension popup and try again.'
+    );
+  }
+
+  // Check if aborted after the call
+  if (signal?.aborted) {
+    throw new Error('AbortError');
+  }
+
+  // Add diagnostic logging for successful responses
+  if (response.success) {
+    console.debug(`[repo2txt] sessionFetch: ${url} → ${response.status} (${response.html.length} bytes)`);
+  }
+
+  if (!response.success) {
+    if (response.status === 429) {
+      throw new ProviderError(
+        'GitHub rate limit reached',
+        ErrorCode.RATE_LIMITED,
+        'GitHub rate limit reached while using session mode. Large repositories may require a Personal Access Token. Please wait a moment and try again.'
+      );
+    }
+
+    if (response.status === 401) {
+      throw new ProviderError(
+        'GitHub authentication required',
+        ErrorCode.AUTH_REQUIRED,
+        'You need to be logged into GitHub in your browser to access this repository. Please log into GitHub and try again, or add a Personal Access Token.'
+      );
+    }
+
+    if (response.status === 403) {
+      throw new ProviderError(
+        'GitHub access denied',
+        ErrorCode.AUTH_REQUIRED,
+        'Access to this repository was denied. Make sure you are logged into GitHub in your browser and have access to this repository, or add a Personal Access Token with repo scope.'
+      );
+    }
+
+    if (response.status === 404) {
+      throw new ProviderError(
+        'Repository not found',
+        ErrorCode.NOT_FOUND,
+        "Repository not found. It may be private and you don't have access, or the URL may be incorrect. Make sure you are logged into GitHub in your browser, or add a Personal Access Token."
+      );
+    }
+
+    throw new Error(`HTTP ${response.status}: ${response.error || 'Session fetch failed'}`);
+  }
+
+  return response.html;
+}
+
+  /**
+   * Parse a GitHub repo/directory page to extract file listing and default branch
+   * Uses embedded JSON data when available (more reliable), falls back to DOM parsing
+   */
+  private parseRepoPage(html: string): {
+    files: Array<{ name: string; type: 'file' | 'directory'; path: string }>;
+    defaultBranch: string;
+    currentBranch?: string;
+  } {
+    const files: Array<{ name: string; type: 'file' | 'directory'; path: string }> = [];
+    let defaultBranch = 'main';
+
+    // Try to extract embedded JSON data first (more reliable)
+    // GitHub injects MULTIPLE script tags with embeddedData - we need to check all of them
+    // The first one is rarely the file tree, so we iterate until we find files
+    const embeddedDataRegex =
+      /data-target="react-partial\.embeddedData"\s*>\s*(.*?)\s*<\/script>/gs;
+    let match;
+
+    // Helper function to extract files from JSON payload
+    const extractFiles = (obj: unknown): void => {
+      if (!obj || typeof obj !== 'object') return;
+
+      const record = obj as Record<string, unknown>;
+
+      // Look for items array in tree data
+      if (Array.isArray(record.items)) {
+        for (const item of record.items) {
+          if (item && typeof item === 'object' && 'name' in item && 'path' in item) {
+            const itemObj = item as Record<string, unknown>;
+            files.push({
+              name: String(itemObj.name),
+              type: itemObj.contentType === 'directory' ? 'directory' : 'file',
+              path: String(itemObj.path),
+            });
+          }
+        }
+      }
+
+      // Look for entries array
+      if (Array.isArray(record.entries)) {
+        for (const entry of record.entries) {
+          if (entry && typeof entry === 'object' && 'name' in entry && 'path' in entry) {
+            const entryObj = entry as Record<string, unknown>;
+            files.push({
+              name: String(entryObj.name),
+              type: entryObj.type === 'tree' ? 'directory' : 'file',
+              path: String(entryObj.path),
+            });
+          }
+        }
+      }
+
+      // Recursively search nested objects
+      for (const value of Object.values(record)) {
+        if (typeof value === 'object' && value !== null) {
+          extractFiles(value);
+        }
+      }
+    };
+
+    // Helper function to extract default branch from JSON payload
+    const extractBranch = (obj: unknown): string | null => {
+      if (!obj || typeof obj !== 'object') return null;
+      const record = obj as Record<string, unknown>;
+
+      if (typeof record.defaultBranch === 'string') return record.defaultBranch;
+      if (typeof record.default_branch === 'string') return record.default_branch;
+      // Removed fallback to default_branch to avoid returning the wrong branch
+
+      for (const value of Object.values(record)) {
+        if (typeof value === 'object' && value !== null) {
+          const found = extractBranch(value);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+
+    // Helper function to extract the current branch (the branch being viewed)
+    // from JSON payload. This is important for resolving branch names with slashes.
+    const extractCurrentBranch = (obj: unknown): string | null => {
+      if (!obj || typeof obj !== 'object') return null;
+      const record = obj as Record<string, unknown>;
+
+      // GitHub React payloads use various keys for the current branch
+      if (typeof record.refName === 'string') return record.refName;
+      if (typeof record.branch === 'string') return record.branch;
+      if (typeof record.currentBranch === 'string') return record.currentBranch;
+      if (record.repo && typeof record.repo === 'object') {
+        const repo = record.repo as Record<string, unknown>;
+        if (typeof repo.default_branch === 'string') return repo.default_branch;
+      }
+
+      for (const value of Object.values(record)) {
+        if (typeof value === 'object' && value !== null) {
+          const found = extractCurrentBranch(value);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+
+    let currentBranch: string | undefined;
+
+    // Iterate through all embeddedData script tags until we find one with files
+    while ((match = embeddedDataRegex.exec(html)) !== null) {
+      try {
+        const jsonData = JSON.parse(match[1]);
+        extractFiles(jsonData);
+
+        // Try to extract default branch from this payload
+        const foundBranch = extractBranch(jsonData);
+        if (foundBranch) defaultBranch = foundBranch;
+
+        // Try to extract current branch from this payload
+        const foundCurrentBranch = extractCurrentBranch(jsonData);
+        if (foundCurrentBranch) currentBranch = foundCurrentBranch;
+
+        // If we found files, we can stop looking
+        if (files.length > 0) break;
+      } catch {
+        // JSON parsing failed for this script tag, try the next one
+        continue;
+      }
+    }
+
+    // Fallback: DOM parsing for file list
+    if (files.length === 0) {
+      // Match file/directory rows
+      // Files: href="/owner/repo/blob/branch/path"
+      // Directories: href="/owner/repo/tree/branch/path"
+      const rowRegex =
+        /<div[^>]*role="rowheader"[^>]*>[\s\S]*?<a[^>]*href="\/[^/]+\/[^/]+\/(blob|tree)\/([^/]+)\/([^"]+)"[^>]*>([^<]+)<\/a>[\s\S]*?<\/div>/g;
+
+      let match;
+      while ((match = rowRegex.exec(html)) !== null) {
+        const [, linkType, , path, name] = match;
+        files.push({
+          name: name.trim(),
+          type: linkType === 'tree' ? 'directory' : 'file',
+          path: path.trim(),
+        });
+      }
+
+      // Alternative: simpler link matching
+      if (files.length === 0) {
+        const linkRegex =
+          /<a[^>]*href="\/[^/]+\/[^/]+\/(blob|tree)\/([^/]+)\/([^"]+)"[^>]*>([^<]+)<\/a>/g;
+        while ((match = linkRegex.exec(html)) !== null) {
+          const [, linkType, , path, name] = match;
+          // Skip navigation links (usually have specific classes)
+          if (!path.includes('?') && !name.includes('<')) {
+            files.push({
+              name: name.trim(),
+              type: linkType === 'tree' ? 'directory' : 'file',
+              path: path.trim(),
+            });
+ }
+ }
+ }
+
+ // Log when DOM fallback is used
+ if (files.length === 0) {
+ console.warn('[repo2txt] parseRepoPage: embeddedData parsing found 0 files, trying DOM fallback');
+ }
+ }
+
+    // Extract default branch from branch selector button if not found
+    if (defaultBranch === 'main') {
+      const branchMatch = html.match(/<button[^>]*data-hotkey="w"[^>]*>([^<]+)<\/button>/);
+      if (branchMatch) {
+        defaultBranch = branchMatch[1].trim();
+      } else {
+        // Try alternative: branch in title or header
+        const titleMatch = html.match(
+          /<span[^>]*class="[^"]*branch-name[^"]*"[^>]*>([^<]+)<\/span>/
+        );
+        if (titleMatch) {
+          defaultBranch = titleMatch[1].trim();
+        }
+      }
+    }
+
+    console.debug(`[repo2txt] parseRepoPage: found ${files.length} files, defaultBranch=${defaultBranch}, currentBranch=${currentBranch ?? 'none'}`);
+
+    return { files, defaultBranch, currentBranch };
+  }
+
+  /**
+   * Parse a directory page to extract file/directory listing
+   */
+  private parseDirectoryPage(
+    html: string
+  ): Array<{ name: string; type: 'file' | 'directory'; path: string }> {
+    const { files } = this.parseRepoPage(html);
+    return files;
+  }
+
+  /**
+   * Fetch file tree using session mode (github.com web endpoints)
+   * Recursively fetches directories with concurrency control
+   */
+  /**
+ * Fetch file tree using session mode (github.com web endpoints)
+ * Recursively fetches directories with concurrency control
+ */
+private async fetchTreeSession(
+  owner: string,
+  repo: string,
+  branch: string,
+  basePath: string,
+  signal?: AbortSignal
+): Promise<FileNode[]> {
+  const allNodes: FileNode[] = [];
+  const queue: Array<{ path: string; depth: number }> = [{ path: basePath, depth: 0 }];
+  const MAX_CONCURRENT = 3;
+
+  const processQueueItem = async (item: { path: string; depth: number }): Promise<FileNode[]> => {
+    // Check if aborted before processing
+    if (signal?.aborted) {
+      throw new Error('AbortError');
+    }
+
+    const pathSegment = item.path ? `/${item.path}` : '';
+    const url = `${GitHubProvider.WEB_BASE}/${owner}/${repo}/tree/${branch}${pathSegment}`;
+
+    const html = await this.sessionFetch(url, signal);
+    const files = this.parseDirectoryPage(html);
+
+    if (files.length === 0) {
+      throw new ProviderError(
+        'Could not parse GitHub page',
+        ErrorCode.PROVIDER_ERROR,
+        "Could not parse GitHub page. This may happen if you're not logged into GitHub, or GitHub's page structure has changed. Please try using a Personal Access Token, or check for extension updates."
+      );
+    }
+
+    const nodes: FileNode[] = [];
+    const subdirs: Array<{ path: string; depth: number }> = [];
+
+    for (const file of files) {
+      // Check if aborted between files
+      if (signal?.aborted) {
+        throw new Error('AbortError');
+      }
+
+      const fullPath = item.path ? `${item.path}/${file.name}` : file.name;
+      const isDirectory = file.type === 'directory';
+
+      nodes.push({
+        path: fullPath,
+        type: isDirectory ? 'tree' : 'blob',
+        url: `${GitHubProvider.WEB_BASE}/${owner}/${repo}/${isDirectory ? 'tree' : 'blob'}/${branch}/${fullPath}`,
+        urlType: 'web',
+        // SHA not available from web scraping
+      });
+
+      if (isDirectory) {
+        subdirs.push({ path: fullPath, depth: item.depth + 1 });
+      }
+    }
+
+    // Add subdirectories to queue
+    queue.push(...subdirs);
+
+    return nodes;
+  };
+
+  // Process with concurrency control
+  while (queue.length > 0) {
+    // Check if aborted between batches
+    if (signal?.aborted) {
+      throw new Error('AbortError');
+    }
+
+    const batch = queue.splice(0, MAX_CONCURRENT);
+    const results = await Promise.all(batch.map(processQueueItem));
+
+    for (const nodes of results) {
+      allNodes.push(...nodes);
+    }
+
+    // Small delay between batches to avoid rate limiting
+    if (queue.length > 0) {
+      await this.delay(100);
+    }
+  }
+
+  return allNodes;
+}
+
+/**
+ * Fetch file content using session mode (github.com raw URLs)
+ */
+  private async fetchFileSession(node: FileNode, signal?: AbortSignal): Promise<FileContent> {
+  let rawUrl: string;
+
+  if (node.urlType === 'web' && node.url?.includes('/blob/')) {
+    // Session-mode node: convert blob URL to raw URL
+    rawUrl = node.url.replace('/blob/', '/raw/');
+  } else if (this.repoInfo?.owner) {
+    // PAT-mode node falling back to session: construct web URL from repo metadata
+    const branch = this.repoInfo.branch || 'HEAD';
+    rawUrl = `${GitHubProvider.WEB_BASE}/${this.repoInfo.owner}/${this.repoInfo.repo}/raw/${branch}/${node.path}`;
+  } else {
+    throw new ProviderError(
+      'Cannot construct session URL for file',
+      ErrorCode.INVALID_URL,
+      'Cannot fetch file: missing URL or repo metadata'
+    );
+  }
+
+  const text = await this.sessionFetch(rawUrl, signal);
+
+  return {
+    path: node.path,
+    text,
+    url: rawUrl,
+    lineCount: text.split('\n').length,
+  };
+}
+
+  /**
+   * Resolve branch and path for session mode by fetching the repo page
+   */
+  private async resolveSessionRefAndPath(
+    owner: string,
+    repo: string,
+    urlBranch: string | undefined
+  ): Promise<{ branch: string; path: string }> {
+    if (!urlBranch && this.sessionDefaultBranch) {
+      return { branch: this.sessionDefaultBranch, path: '' };
+    }
+
+    const repoUrl = urlBranch
+      ? `${GitHubProvider.WEB_BASE}/${owner}/${repo}/tree/${urlBranch}`
+      : `${GitHubProvider.WEB_BASE}/${owner}/${repo}`;
+    const html = await this.sessionFetch(repoUrl);
+    const { defaultBranch, currentBranch } = this.parseRepoPage(html);
+
+    this.sessionDefaultBranch = defaultBranch;
+
+    if (!urlBranch) {
+      return { branch: defaultBranch, path: '' };
+    }
+
+    // If the page reports the current branch, use it directly.
+    // This correctly handles branch names with slashes like "feature/auth/login"
+    if (currentBranch) {
+      const pathPrefix = currentBranch + '/';
+      if (urlBranch === currentBranch) {
+        return { branch: currentBranch, path: '' };
+      }
+      if (urlBranch.startsWith(pathPrefix)) {
+        return { branch: currentBranch, path: urlBranch.slice(currentBranch.length + 1) };
+      }
+    }
+
+    // Fallback: match against known defaultBranch
+    if (urlBranch === defaultBranch || urlBranch.startsWith(defaultBranch + '/')) {
+      return {
+        branch: defaultBranch,
+        path: urlBranch === defaultBranch ? '' : urlBranch.slice(defaultBranch.length + 1),
+      };
+    }
+
+    // Last resort: assume first segment is the branch name
+    const parts = urlBranch.split('/');
+    return {
+      branch: parts[0],
+      path: parts.slice(1).join('/'),
+    };
+  }
 
   getType(): ProviderType {
     return 'github';
@@ -71,87 +550,123 @@ export class GitHubProvider extends BaseProvider {
     };
   }
 
-  /**
-   * Fetch repository file tree
-   */
   async fetchTree(url: string, options?: FetchOptions): Promise<FileNode[]> {
-    const parsed = this.parseUrl(url);
+  const parsed = this.parseUrl(url);
 
-    if (!parsed.isValid) {
-      throw new ProviderError(
-        parsed.error || 'Invalid URL',
-        ErrorCode.INVALID_URL,
-        parsed.error || 'Please provide a valid GitHub repository URL'
-      );
+  if (!parsed.isValid) {
+    throw new ProviderError(
+      parsed.error || 'Invalid URL',
+      ErrorCode.INVALID_URL,
+      parsed.error || 'Please provide a valid GitHub repository URL'
+    );
+  }
+
+  const { owner, repo } = parsed;
+  if (!owner || !repo) {
+    throw new ProviderError(
+      'Missing owner or repo',
+      ErrorCode.INVALID_URL,
+      'Could not extract repository information from URL'
+    );
+  }
+
+  // Store repo metadata
+  this.repoInfo = {
+    type: 'github',
+    name: repo,
+    owner,
+    branch: options?.branch || parsed.branch,
+    path: options?.path || parsed.path,
+    url,
+  };
+
+  const cacheKey = `${url}${options?.branch ? `#${options.branch}` : ''}`;
+  const { getCachedRepo, setCachedRepo } = useStore.getState();
+  const cached = getCachedRepo(cacheKey);
+
+  if (cached) {
+    return cached.data;
+  }
+
+  try {
+    // Session mode: use github.com web endpoints
+    if (this.sessionMode) {
+      const resolved = await this.resolveSessionRefAndPath(owner, repo, parsed.branch, options?.signal);
+      const branch = options?.branch || resolved.branch;
+      const path = options?.path || resolved.path;
+
+      this.repoInfo.branch = branch;
+      this.repoInfo.path = path;
+
+      const tree = await this.fetchTreeSession(owner, repo, branch, path, options?.signal);
+      setCachedRepo(cacheKey, tree, []);
+      return tree;
     }
 
-    const { owner, repo } = parsed;
-    if (!owner || !repo) {
-      throw new ProviderError(
-        'Missing owner or repo',
-        ErrorCode.INVALID_URL,
-        'Could not extract repository information from URL'
-      );
-    }
+    // PAT mode: use api.github.com endpoints
+    let ref = options?.branch || parsed.branch || '';
+    let path = options?.path || parsed.path || '';
 
-    // Store repo metadata
-    this.repoInfo = {
-      type: 'github',
-      name: repo,
-      owner,
-      branch: options?.branch || parsed.branch,
-      path: options?.path || parsed.path,
-      url,
-    };
-
-    const cacheKey = `${url}${options?.branch ? `#${options.branch}` : ''}`;
-    const { getCachedRepo, setCachedRepo } = useStore.getState();
-    const cached = getCachedRepo(cacheKey);
-
-    if (cached) {
-      return cached.data;
+    if (parsed.branch) {
+      const references = await this.fetchReferences(owner, repo, options?.signal);
+      const resolved = this.resolveRefAndPath(parsed.branch, references);
+      ref = resolved.ref;
+      path = resolved.path;
     }
 
     try {
-      // Resolve branch/path if URL contains tree segment
-      let ref = options?.branch || parsed.branch || '';
-      let path = options?.path || parsed.path || '';
-
-      if (parsed.branch) {
-        const references = await this.fetchReferences(owner, repo);
-        const resolved = this.resolveRefAndPath(parsed.branch, references);
-        ref = resolved.ref;
-        path = resolved.path;
-      }
-
-      // Fetch the tree SHA
-      const sha = await this.fetchTreeSha(owner, repo, ref, path);
-
-      // Fetch the complete tree
-      const tree = await this.fetchTreeRecursive(owner, repo, sha);
-
+      const sha = await this.fetchTreeSha(owner, repo, ref, path, options?.signal);
+      const tree = await this.fetchTreeRecursive(owner, repo, sha, options?.signal);
       setCachedRepo(cacheKey, tree, []);
-
       return tree;
     } catch (error) {
-      throw this.handleFetchError(error, `${owner}/${repo}`);
+      // Re-throw AbortError without fallback
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
+      }
+      // PAT got 404/403: fall back to session mode
+      if (this.credentials?.token && this.is404or403Error(error)) {
+        this.sessionMode = true;
+        const resolved = await this.resolveSessionRefAndPath(owner, repo, parsed.branch, options?.signal);
+        const branch = options?.branch || resolved.branch;
+        const path = options?.path || resolved.path;
+
+        this.repoInfo.branch = branch;
+        this.repoInfo.path = path;
+
+        const tree = await this.fetchTreeSession(owner, repo, branch, path, options?.signal);
+        setCachedRepo(cacheKey, tree, []);
+        return tree;
+      }
+      throw error;
     }
+  } catch (error) {
+    // Re-throw AbortError without wrapping
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error;
+    }
+    throw this.handleFetchError(error, `${owner}/${repo}`);
   }
+}
 
   /**
    * Fetch references (branches and tags)
    */
-  private async fetchReferences(owner: string, repo: string): Promise<GitHubReferences> {
+  private async fetchReferences(owner: string, repo: string, signal?: AbortSignal): Promise<GitHubReferences> {
     const headers = this.buildGitHubHeaders();
 
     const [branchesResponse, tagsResponse] = await Promise.all([
       this.fetchWithRetry(
         `${GitHubProvider.API_BASE}/repos/${owner}/${repo}/git/matching-refs/heads/`,
-        { headers }
+        { headers },
+        1,
+        signal
       ),
       this.fetchWithRetry(
         `${GitHubProvider.API_BASE}/repos/${owner}/${repo}/git/matching-refs/tags/`,
-        { headers }
+        { headers },
+        1,
+        signal
       ),
     ]);
 
@@ -163,6 +678,7 @@ export class GitHubProvider extends BaseProvider {
       tags: tagsData.map((t: { ref: string }) => t.ref.split('/').slice(2).join('/')),
     };
   }
+
 
   /**
    * Resolve ref and path from URL segment
@@ -211,7 +727,8 @@ export class GitHubProvider extends BaseProvider {
     owner: string,
     repo: string,
     ref: string,
-    path: string
+    path: string,
+    signal?: AbortSignal
   ): Promise<string> {
     const headers = this.buildGitHubHeaders({
       Accept: 'application/vnd.github.object+json',
@@ -221,129 +738,163 @@ export class GitHubProvider extends BaseProvider {
     const refParam = ref ? `?ref=${encodeURIComponent(ref)}` : '';
     const url = `${GitHubProvider.API_BASE}/repos/${owner}/${repo}/contents${pathSegment}${refParam}`;
 
-    const response = await this.fetchWithRetry(url, { headers });
+    const response = await this.fetchWithRetry(url, { headers }, 1, signal);
     const data = await response.json();
 
     return data.sha;
   }
 
+
   /**
    * Fetch complete file tree recursively
    */
-  private async fetchTreeRecursive(owner: string, repo: string, sha: string): Promise<FileNode[]> {
-    const headers = this.buildGitHubHeaders({
-      Accept: 'application/vnd.github+json',
+  /**
+ * Fetch complete file tree recursively
+ */
+private async fetchTreeRecursive(owner: string, repo: string, sha: string, signal?: AbortSignal): Promise<FileNode[]> {
+  const headers = this.buildGitHubHeaders({
+    Accept: 'application/vnd.github+json',
+  });
+
+  const url = `${GitHubProvider.API_BASE}/repos/${owner}/${repo}/git/trees/${sha}?recursive=1`;
+  const response = await this.fetchWithRetry(url, { headers }, 1, signal);
+  const data = await response.json();
+
+  if (data.truncated) {
+    return this.fetchTreeManualRecursive(owner, repo, sha, '', signal);
+  }
+
+  return data.tree.map(
+    (item: { path: string; type: string; url: string; size?: number; sha?: string }) => ({
+      path: item.path,
+      type: item.type === 'blob' ? 'blob' : 'tree',
+      url: item.url,
+      urlType: 'api' as const,
+      size: item.size,
+      sha: item.sha,
+    })
+  );
+}
+
+private async fetchTreeManualRecursive(
+  owner: string,
+  repo: string,
+  sha: string,
+  basePath: string,
+  signal?: AbortSignal
+): Promise<FileNode[]> {
+  const headers = this.buildGitHubHeaders({
+    Accept: 'application/vnd.github+json',
+  });
+
+  const url = `${GitHubProvider.API_BASE}/repos/${owner}/${repo}/git/trees/${sha}`;
+  const response = await this.fetchWithRetry(url, { headers }, 1, signal);
+  const data = await response.json();
+
+  const allNodes: FileNode[] = [];
+  const treeTasks: (() => Promise<FileNode[]>)[] = [];
+
+    for (const item of data.tree) {
+      // Check if aborted between items
+      if (signal?.aborted) {
+        const error = new Error('Request aborted');
+        error.name = 'AbortError';
+        throw error;
+      }
+
+
+    const fullPath = basePath ? `${basePath}/${item.path}` : item.path;
+
+    allNodes.push({
+      path: fullPath,
+      type: item.type === 'blob' ? 'blob' : 'tree',
+      url: item.url,
+      urlType: 'api' as const,
+      size: item.size,
+      sha: item.sha,
     });
 
-    const url = `${GitHubProvider.API_BASE}/repos/${owner}/${repo}/git/trees/${sha}?recursive=1`;
-    const response = await this.fetchWithRetry(url, { headers });
-    const data = await response.json();
-
-    if (data.truncated) {
-      return this.fetchTreeManualRecursive(owner, repo, sha, '');
+    if (item.type === 'tree' && item.sha) {
+      treeTasks.push(() =>
+        this.fetchTreeManualRecursive(owner, repo, item.sha as string, fullPath, signal)
+      );
     }
+  }
 
-    return data.tree.map(
-      (item: { path: string; type: string; url: string; size?: number; sha?: string }) => ({
-        path: item.path,
-        type: item.type === 'blob' ? 'blob' : 'tree',
-        url: item.url,
-        urlType: 'api' as const,
-        size: item.size,
-        sha: item.sha,
-      })
+  const chunkSize = 5;
+  for (let i = 0; i < treeTasks.length; i += chunkSize) {
+    // Check if aborted between chunks
+      if (signal?.aborted) {
+        const error = new Error('Request aborted');
+    error.name = 'AbortError';
+      throw error;
+}
+
+    const chunk = treeTasks.slice(i, i + chunkSize);
+    const results = await Promise.all(chunk.map((task) => task()));
+    for (const subNodes of results) {
+      allNodes.push(...subNodes);
+    }
+  }
+
+  return allNodes;
+}
+
+/**
+ * Fetch a single file's content (override to handle GitHub's base64 encoding)
+ */
+  async fetchFile(node: FileNode, signal?: AbortSignal): Promise<FileContent> {
+  if (!node.url) {
+    throw new ProviderError(
+      'File node has no URL',
+      ErrorCode.INVALID_URL,
+      'Cannot fetch file: missing URL'
     );
   }
 
-  private async fetchTreeManualRecursive(
-    owner: string,
-    repo: string,
-    sha: string,
-    basePath: string
-  ): Promise<FileNode[]> {
-    const headers = this.buildGitHubHeaders({
-      Accept: 'application/vnd.github+json',
-    });
+  try {
+    // Session mode: use raw github.com URLs
+    if (this.sessionMode) {
+      return this.fetchFileSession(node, signal);
+    }
 
-    const url = `${GitHubProvider.API_BASE}/repos/${owner}/${repo}/git/trees/${sha}`;
-    const response = await this.fetchWithRetry(url, { headers });
+    // PAT mode: use api.github.com endpoints
+    const headers = this.buildGitHubHeaders();
+    const response = await this.fetchWithRetry(node.url, { headers }, 1, signal);
     const data = await response.json();
 
-    const allNodes: FileNode[] = [];
-    const treeTasks: (() => Promise<FileNode[]>)[] = [];
-
-    for (const item of data.tree) {
-      const fullPath = basePath ? `${basePath}/${item.path}` : item.path;
-
-      allNodes.push({
-        path: fullPath,
-        type: item.type === 'blob' ? 'blob' : 'tree',
-        url: item.url,
-        urlType: 'api' as const,
-        size: item.size,
-        sha: item.sha,
-      });
-
-      if (item.type === 'tree' && item.sha) {
-        treeTasks.push(() =>
-          this.fetchTreeManualRecursive(owner, repo, item.sha as string, fullPath)
-        );
+    // GitHub returns base64-encoded content
+    let text = data.content || '';
+    if (data.encoding === 'base64') {
+      // Remove whitespace/newlines from base64 string
+      text = text.replace(/\s/g, '');
+      // Decode base64 to binary string, then convert to UTF-8
+      const binaryString = atob(text);
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
       }
+      text = new TextDecoder('utf-8').decode(bytes);
     }
 
-    const chunkSize = 5;
-    for (let i = 0; i < treeTasks.length; i += chunkSize) {
-      const chunk = treeTasks.slice(i, i + chunkSize);
-      const results = await Promise.all(chunk.map((task) => task()));
-      for (const subNodes of results) {
-        allNodes.push(...subNodes);
+    return {
+      path: node.path,
+      text,
+      url: node.url,
+      lineCount: text.split('\n').length,
+    };
+  } catch (error) {
+      // Re-throw AbortError without fallback
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
       }
-    }
-
-    return allNodes;
-  }
-
-  /**
-   * Fetch a single file's content (override to handle GitHub's base64 encoding)
-   */
-  async fetchFile(node: FileNode): Promise<FileContent> {
-    if (!node.url) {
-      throw new ProviderError(
-        'File node has no URL',
-        ErrorCode.INVALID_URL,
-        'Cannot fetch file: missing URL'
-      );
-    }
-
-    try {
-      const headers = this.buildGitHubHeaders();
-      const response = await this.fetchWithRetry(node.url, { headers });
-      const data = await response.json();
-
-      // GitHub returns base64-encoded content
-      let text = data.content || '';
-      if (data.encoding === 'base64') {
-        // Remove whitespace/newlines from base64 string
-        text = text.replace(/\s/g, '');
-        // Decode base64 to binary string, then convert to UTF-8
-        const binaryString = atob(text);
-        const bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-          bytes[i] = binaryString.charCodeAt(i);
-        }
-        text = new TextDecoder('utf-8').decode(bytes);
-      }
-
-      return {
-        path: node.path,
-        text,
-        url: node.url,
-        lineCount: text.split('\n').length,
-      };
-    } catch (error) {
-      throw this.handleFetchError(error, node.path);
-    }
-  }
+if (this.credentials?.token && this.is404or403Error(error)) {
+this.sessionMode = true;
+return this.fetchFileSession(node, signal);
+}
+throw this.handleFetchError(error, node.path);
+}
+}
 
   /**
    * Build GitHub-specific headers with authentication
@@ -409,5 +960,16 @@ Click the GitHub icon in the authentication section above to add a token.`,
 
     // Use base class error handling for other errors
     return super.handleFetchError(error, context);
+  }
+
+  /**
+   * Check if an error indicates a 404 or 403 response
+   */
+  private is404or403Error(error: unknown): boolean {
+    if (error instanceof Error) {
+      const message = error.message;
+      return message.includes('404') || message.includes('403');
+    }
+    return false;
   }
 }

--- a/src/features/github/components/GitHubAuth.tsx
+++ b/src/features/github/components/GitHubAuth.tsx
@@ -8,41 +8,39 @@ import { Button } from '@/components/ui/Button';
 import { useStore } from '@/store';
 
 export function GitHubAuth() {
-  const { setCredentials } = useStore();
+  const { setCredentials, setPAT, clearPAT } = useStore();
   const [token, setToken] = useState('');
   const [showInfo, setShowInfo] = useState(false);
   const [showToken, setShowToken] = useState(false);
 
-  // Load saved token from sessionStorage on mount
-  useEffect(() => {
-    const savedToken = sessionStorage.getItem('github_token');
-    if (savedToken) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setToken(savedToken);
-
-      setCredentials({ token: savedToken });
-    }
-  }, [setCredentials]);
+ // Load saved token from Zustand store on mount
+ useEffect(() => {
+ const { pat } = useStore.getState();
+ if (pat) {
+ setToken(pat);
+ setCredentials({ token: pat });
+ }
+ }, [setCredentials]);
 
   const handleTokenChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newToken = e.target.value;
     setToken(newToken);
 
-    // Save to sessionStorage and store
-    if (newToken) {
-      sessionStorage.setItem('github_token', newToken);
-      setCredentials({ token: newToken });
-    } else {
-      sessionStorage.removeItem('github_token');
-      setCredentials({ token: undefined });
-    }
+ // Save to store
+ if (newToken) {
+ setCredentials({ token: newToken });
+ setPAT(newToken);
+ } else {
+ setCredentials({ token: undefined });
+ clearPAT();
+ }
   };
 
-  const handleClearToken = () => {
-    setToken('');
-    sessionStorage.removeItem('github_token');
-    setCredentials({ token: undefined });
-  };
+ const handleClearToken = () => {
+ setToken('');
+ setCredentials({ token: undefined });
+ clearPAT();
+ };
 
   return (
     <div className="space-y-1.5">
@@ -78,9 +76,9 @@ export function GitHubAuth() {
 
       {showInfo && (
         <div className="rounded-md bg-blue-50 dark:bg-blue-900/20 p-2 text-xs">
-          <p className="text-blue-800 dark:text-blue-200 mb-1">
-            Required for private repos & higher rate limits.
-          </p>
+ <p className="text-blue-800 dark:text-blue-200 mb-1">
+ Required for private repos & higher rate limits. For private repos, you can also use session mode (no token needed if you're logged into GitHub in your browser).
+ </p>
           <a
             href="https://github.com/settings/tokens/new?description=repo2txt-extension&scopes=repo"
             target="_blank"

--- a/src/features/github/components/__tests__/GitHubAuth.test.tsx
+++ b/src/features/github/components/__tests__/GitHubAuth.test.tsx
@@ -4,25 +4,33 @@ import userEvent from '@testing-library/user-event';
 import { GitHubAuth } from '../GitHubAuth';
 import { useStore } from '@/store';
 
-// Mock the store
-vi.mock('@/store', () => ({
-  useStore: vi.fn(),
-}));
+// Mock the store - must define mock inside factory to avoid hoisting issues
+vi.mock('@/store', () => {
+ const mockUseStore = vi.fn();
+ mockUseStore.getState = vi.fn();
+ return {
+ useStore: mockUseStore,
+ };
+});
 
 describe('GitHubAuth', () => {
   const mockSetCredentials = vi.fn();
+  const mockSetPAT = vi.fn();
+  const mockClearPAT = vi.fn();
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    sessionStorage.clear();
-    (useStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      credentials: null,
-      setCredentials: mockSetCredentials,
-    });
-  });
+ beforeEach(() => {
+ vi.clearAllMocks();
+ (useStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({ pat: null });
+ (useStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+ credentials: null,
+ setCredentials: mockSetCredentials,
+ setPAT: mockSetPAT,
+ clearPAT: mockClearPAT,
+ });
+ });
 
   afterEach(() => {
-    sessionStorage.clear();
+    vi.clearAllMocks();
   });
 
   it('should render token input field', () => {
@@ -84,17 +92,6 @@ describe('GitHubAuth', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('should save token to sessionStorage when entered', async () => {
-    render(<GitHubAuth />);
-
-    const input = screen.getByPlaceholderText('ghp_...');
-    const token = 'ghp_testtoken123';
-
-    await userEvent.type(input, token);
-
-    expect(sessionStorage.getItem('github_token')).toBe(token);
-  });
-
   it('should update store when token is entered', async () => {
     render(<GitHubAuth />);
 
@@ -108,16 +105,16 @@ describe('GitHubAuth', () => {
     });
   });
 
-  it('should load saved token from sessionStorage on mount', () => {
-    const savedToken = 'ghp_savedtoken456';
-    sessionStorage.setItem('github_token', savedToken);
+ it('should load saved token from store on mount', () => {
+ const savedToken = 'ghp_savedtoken456';
+ (useStore.getState as ReturnType<typeof vi.fn>).mockReturnValue({ pat: savedToken });
 
-    render(<GitHubAuth />);
+ render(<GitHubAuth />);
 
-    const input = screen.getByPlaceholderText('ghp_...') as HTMLInputElement;
-    expect(input.value).toBe(savedToken);
-    expect(mockSetCredentials).toHaveBeenCalledWith({ token: savedToken });
-  });
+ const input = screen.getByPlaceholderText('ghp_...') as HTMLInputElement;
+ expect(input.value).toBe(savedToken);
+ expect(mockSetCredentials).toHaveBeenCalledWith({ token: savedToken });
+ });
 
   it('should show clear button when token is entered', async () => {
     render(<GitHubAuth />);
@@ -151,7 +148,6 @@ describe('GitHubAuth', () => {
     await userEvent.click(clearButton);
 
     expect(input.value).toBe('');
-    expect(sessionStorage.getItem('github_token')).toBeNull();
     expect(mockSetCredentials).toHaveBeenCalledWith({ token: undefined });
   });
 
@@ -169,19 +165,6 @@ describe('GitHubAuth', () => {
     await waitFor(() => {
       expect(screen.getByText(/Token saved/i)).toBeInTheDocument();
     });
-  });
-
-  it('should remove token from sessionStorage when cleared', async () => {
-    render(<GitHubAuth />);
-
-    const input = screen.getByPlaceholderText('ghp_...');
-    await userEvent.type(input, 'ghp_testtoken123');
-
-    expect(sessionStorage.getItem('github_token')).toBe('ghp_testtoken123');
-
-    await userEvent.clear(input);
-
-    expect(sessionStorage.getItem('github_token')).toBeNull();
   });
 
   it('should update credentials in store when token is cleared', async () => {
@@ -231,7 +214,7 @@ describe('GitHubAuth', () => {
     await userEvent.type(input, 'ghp_token2');
 
     await waitFor(() => {
-      expect(sessionStorage.getItem('github_token')).toBe('ghp_token2');
+      expect(mockSetCredentials).toHaveBeenLastCalledWith({ token: 'ghp_token2' });
     });
   });
 });

--- a/src/hooks/useLoadQueue.ts
+++ b/src/hooks/useLoadQueue.ts
@@ -1,0 +1,86 @@
+import { useState, useCallback, useRef } from 'react';
+import type { FileNode } from '@/types';
+import type { IProvider } from '@/lib/providers/types';
+
+interface LoadTask {
+  id: string;
+  url: string;
+  provider: IProvider;
+  abortController: AbortController;
+  status: 'loading' | 'completed' | 'cancelled' | 'error';
+  error?: Error;
+  result?: FileNode[];
+}
+
+export function useLoadQueue() {
+  const [loading, setLoading] = useState(false);
+  const taskRef = useRef<LoadTask | null>(null);
+
+  const start = useCallback(
+    async (provider: IProvider, url: string): Promise<FileNode[] | null> => {
+      // Cancel previous task if exists
+      if (taskRef.current) {
+        taskRef.current.abortController.abort();
+        taskRef.current.status = 'cancelled';
+      }
+
+      // Create new task
+      const task: LoadTask = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+        url,
+        provider,
+        abortController: new AbortController(),
+        status: 'loading',
+      };
+
+      taskRef.current = task;
+      setLoading(true);
+
+      try {
+        const result = await provider.fetchTree(url, {
+          signal: task.abortController.signal,
+        });
+
+        // Check if aborted after fetch
+        if (task.abortController.signal.aborted) {
+          return null;
+        }
+
+        task.status = 'completed';
+        task.result = result;
+        return result;
+      } catch (error) {
+        // Handle AbortError
+        if (error instanceof Error && error.name === 'AbortError') {
+          task.status = 'cancelled';
+          return null;
+        }
+
+        task.status = 'error';
+        task.error = error instanceof Error ? error : new Error(String(error));
+        throw error;
+      } finally {
+        // Only clear loading if this task wasn't aborted
+        if (!task.abortController.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    []
+  );
+
+  const cancel = useCallback(() => {
+    if (taskRef.current) {
+      taskRef.current.abortController.abort();
+      taskRef.current.status = 'cancelled';
+      taskRef.current = null;
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    loading,
+    start,
+    cancel,
+  };
+}

--- a/src/lib/file-tree/FileNode.ts
+++ b/src/lib/file-tree/FileNode.ts
@@ -8,7 +8,7 @@ export class FileNode {
   path: string;
   type: 'blob' | 'tree';
   url?: string;
-  urlType?: 'api' | 'directory' | 'zip';
+  urlType?: 'api' | 'directory' | 'zip' | 'web';
   size?: number;
   sha?: string;
   selected: boolean = false;

--- a/src/lib/providers/BaseProvider.ts
+++ b/src/lib/providers/BaseProvider.ts
@@ -55,7 +55,7 @@ export abstract class BaseProvider implements IProvider {
   /**
    * Fetch a single file's content
    */
-  async fetchFile(node: FileNode): Promise<FileContent> {
+  async fetchFile(node: FileNode, signal?: AbortSignal): Promise<FileContent> {
     if (!node.url) {
       throw new ProviderError(
         'File node has no URL',
@@ -65,7 +65,7 @@ export abstract class BaseProvider implements IProvider {
     }
 
     try {
-      const response = await this.fetchWithRetry(node.url);
+      const response = await this.fetchWithRetry(node.url, undefined, 1, signal);
       const text = await response.text();
 
       return {
@@ -75,16 +75,25 @@ export abstract class BaseProvider implements IProvider {
         lineCount: text.split('\n').length,
       };
     } catch (error) {
+      // Re-throw AbortError without wrapping
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
+      }
       throw this.handleFetchError(error, node.path);
     }
   }
 
-  async *fetchMultiple(nodes: FileNode[]): AsyncGenerator<FileContent, void, unknown> {
+  async *fetchMultiple(nodes: FileNode[], signal?: AbortSignal): AsyncGenerator<FileContent, void, unknown> {
     const { maxConcurrent, delayMs } = this.rateLimiter;
 
     for (let i = 0; i < nodes.length; i += maxConcurrent) {
+      // Check for abort between chunks
+      if (signal?.aborted) {
+        break;
+      }
+
       const chunk = nodes.slice(i, i + maxConcurrent);
-      const results = await Promise.allSettled(chunk.map((node) => this.fetchFile(node)));
+      const results = await Promise.allSettled(chunk.map((node) => this.fetchFile(node, signal)));
 
       for (const result of results) {
         if (result.status === 'fulfilled') {
@@ -119,10 +128,18 @@ export abstract class BaseProvider implements IProvider {
   protected async fetchWithRetry(
     url: string,
     options?: RequestInit,
-    attempt = 1
+    attempt = 1,
+    signal?: AbortSignal
   ): Promise<Response> {
+    // Check if already aborted before starting
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+
     try {
-      const response = await fetch(url, options);
+      const response = await fetch(url, { ...options, signal });
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -130,9 +147,14 @@ export abstract class BaseProvider implements IProvider {
 
       return response;
     } catch (error) {
+      // Don't retry on AbortError
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
+      }
+
       if (attempt < (this.rateLimiter.retries || 3)) {
         await this.delay(this.rateLimiter.retryDelayMs || 1000);
-        return this.fetchWithRetry(url, options, attempt + 1);
+        return this.fetchWithRetry(url, options, attempt + 1, signal);
       }
       throw error;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export interface FileNode {
   path: string;
   type: 'blob' | 'tree';
   url?: string;
-  urlType?: 'api' | 'directory' | 'zip';
+  urlType?: 'api' | 'directory' | 'zip' | 'web';
   size?: number;
   sha?: string;
 }
@@ -36,9 +36,10 @@ export interface ProviderCredentials {
 }
 
 export interface FetchOptions {
-  branch?: string;
-  path?: string;
+branch?: string;
+path?: string;
   credentials?: ProviderCredentials;
+  signal?: AbortSignal;
 }
 
 export interface TreeNode {


### PR DESCRIPTION
When no PAT is provided, the extension now falls back to session mode which uses the browser's GitHub cookies via the background service worker. This gives authenticated access without requiring a token.

- Add sessionMode to GitHubProvider with cookie-authenticated fetch
- Add useLoadQueue hook for cancellable, abort-aware repo loading
- Add GITHUB_WEB_FETCH message handler in background script
- Parse GitHub's embedded React data for file tree extraction
- Fall back from PAT to session mode on 403/404
- Resolve branch names with slashes (e.g. feature/auth/login)
- Add scripts/package-crx.ts for Chrome Web Store packaging
- Move CI checks out of deploy workflow
- Update CONTRIBUTING.md with development guide
- Add session mode coverage to GitHubAuth tests