### PR TITLE
Docs cleanup and CRX release packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tests/test-config.ts
 test-results/
 playwright-report/
 playwright/.cache/
+
+# Build artifacts
+release/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to repo2txt
 
-Thank you for your interest in contributing! This document provides comprehensive guidance on the project architecture, design patterns, and development workflow.
+Thank you for your interest in contributing. This document provides guidance on the project architecture, design patterns, and development workflow.
 
-## 📋 Table of Contents
+## Table of Contents
 
 - [Getting Started](#getting-started)
 - [Architecture Overview](#architecture-overview)
@@ -13,7 +13,7 @@ Thank you for your interest in contributing! This document provides comprehensiv
 - [Code Style](#code-style)
 - [Pull Request Process](#pull-request-process)
 
-## 🚀 Getting Started
+## Getting Started
 
 ### Prerequisites
 
@@ -35,9 +35,6 @@ git remote add upstream https://github.com/michael-farah/repo2txt-extension.git
 # Install dependencies
 bun install
 
-# Set up git hooks (required for local CI)
-git config core.hooksPath .githooks
-
 # Copy test configuration template
 cp tests/test-config.example.ts tests/test-config.ts
 # Add your GitHub token to test-config.ts (optional, for E2E tests)
@@ -50,91 +47,28 @@ bun run dev
 
 ```bash
 # Development
-bun run dev              # Start dev server (http://localhost:5173/)
-bun run build            # Production build
-bun run preview          # Preview production build
+bun run dev # Start dev server (http://localhost:5173/)
+bun run build # Production build
+bun run preview # Preview production build
 
 # Testing
-bun run test:unit        # Run unit tests
-bun run test:e2e         # Run E2E tests
-bun run test:watch       # Watch mode for unit tests
-bun run test:coverage    # Generate coverage report
+bun run test:unit # Run unit tests
+bun run test:e2e # Run E2E tests
+bun run test:watch # Watch mode for unit tests
+bun run test:coverage # Generate coverage report
 
 # Code Quality
-bun run typecheck        # TypeScript type checking
-bun run lint             # Lint code
-bun run lint:fix         # Auto-fix linting issues
-bun run format           # Format code with Prettier
-bun run format:check     # Check formatting
+bun run typecheck # TypeScript type checking
+bun run lint # Lint code
+bun run lint:fix # Auto-fix linting issues
+bun run format # Format code with Prettier
+bun run format:check # Check formatting
 
 # CI Pipeline (runs all checks)
-bun run ci               # typecheck + lint + test:unit
+bun run ci # typecheck + lint + test:unit
 ```
 
-## 🔧 Local CI with Act
-
-This project supports running CI checks locally using [nektos/act](https://github.com/nektos/act), which runs GitHub Actions workflows in Docker containers. This provides fast feedback without pushing to GitHub.
-
-### Prerequisites
-
-1. **Install act**: `brew install act` or see the [installation guide](https://nektosact.com/installation/index.html)
-2. **Docker must be running** — act uses Docker to run workflow containers
-
-### Running CI Locally
-
-```bash
-# Run the full CI workflow (typecheck + lint + test + build)
-act -W .github/workflows/ci.yml
-
-# Run only the ci job
-act -W .github/workflows/ci.yml -j ci
-
-# Dry run (list steps without executing)
-act -W .github/workflows/ci.yml -n
-
-# List all available jobs
-act -l
-
-# Skip pulling Docker images on subsequent runs
-act -W .github/workflows/ci.yml --pull=false
-```
-
-### Pre-Commit Hook
-
-A pre-commit hook is configured to automatically run CI checks via `act` before each commit. This ensures code quality is validated locally before pushing.
-
-```bash
-# Normal commit — hook runs CI automatically
-git commit -m "feat: new feature"
-
-# Skip the hook (not recommended, use for WIP commits only)
-git commit --no-verify -m "wip: work in progress"
-```
-
-### Secrets Configuration
-
-Copy the secrets template and fill in values if needed:
-
-```bash
-cp .secrets.example .secrets
-# Edit .secrets with your values (optional for CI checks)
-```
-
-The `.secrets` file is git-ignored and read by act via `.actrc`.
-
-### Workflow Structure
-
-- **`ci.yml`** — Act-compatible CI workflow (typecheck, lint, test, build). Only triggers via `workflow_dispatch` (run locally with `act`, not on GitHub push).
-- **`deploy.yml`** — GitHub Pages deployment only. Runs on push to main/master. Not run locally (uses GitHub-specific Pages actions).
-
-### Troubleshooting
-
-- **Image pull errors**: Run `act --pull` first to download runner images
-- **Permission denied on hook**: `chmod +x .githooks/pre-commit`
-- **Slow first run**: Act downloads Docker images (~2GB) on first use
-- **Docker not running**: Start Docker Desktop or the Docker daemon
-
-## 🏗️ Architecture Overview
+## Architecture Overview
 
 ### Core Design Principles
 
@@ -148,25 +82,25 @@ The `.secrets` file is git-ignored and read by act via `.actrc`.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                      React App                          │
+│ React App                                               │
 ├─────────────────────────────────────────────────────────┤
-│  ┌─────────────┐  ┌──────────────┐  ┌──────────────┐  │
-│  │     UI      │  │     Store    │  │   Workers    │  │
-│  │ Components  │◄─┤   (Zustand)  │◄─┤ (Tokenizer)  │  │
-│  └─────────────┘  └──────────────┘  └──────────────┘  │
-│         ▲                 ▲                             │
-│         │                 │                             │
-│         ▼                 ▼                             │
-│  ┌─────────────────────────────────────────────────┐  │
-│  │           Provider Interface                    │  │
-│  │  (BaseProvider - Abstract Base Class)           │  │
-│  └─────────────────────────────────────────────────┘  │
-│         ▲         ▲          ▲           ▲             │
-│         │         │          │           │             │
-│    ┌────┴───┬────┴────┬─────┴─────┬────┴────┐        │
-│    │ GitHub │  Local  │  GitLab   │  Azure  │        │
-│    │Provider│ Provider│  Provider │Provider │        │
-│    └────────┴─────────┴───────────┴─────────┘        │
+│ ┌─────────────┐ ┌──────────────┐ ┌──────────────┐       │
+│ │ UI          │ │ Store        │ │ Workers      │       │
+│ │ Components  │◄─┤ (Zustand)    │◄─┤ (Tokenizer)  │       │
+│ └─────────────┘ └──────────────┘ └──────────────┘       │
+│ ▲           ▲                                           │
+│ │           │                                           │
+│ ▼           ▼                                           │
+│ ┌─────────────────────────────────────────────────┐     │
+│ │ Provider Interface                                │     │
+│ │ (BaseProvider - Abstract Base Class)            │     │
+│ └─────────────────────────────────────────────────┘     │
+│ ▲      ▲      ▲      ▲                                  │
+│ │      │      │      │                                  │
+│ ┌────┴───┬────┴────┬─────┴─────┬────┴────┐              │
+│ │ GitHub │ Local   │ GitLab    │ Azure   │              │
+│ │Provider│ Provider│ Provider  │Provider │              │
+│ └────────┴─────────┴───────────┴─────────┘              │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -174,15 +108,15 @@ The `.secrets` file is git-ignored and read by act via `.actrc`.
 
 ```
 User Input → URL Parsing → Provider Selection → Tree Fetch
-    ↓
+                ↓
 File Tree (Virtual Scrolling) → User Selection → Filters
-    ↓
+                ↓
 Content Fetch → Formatting → Tokenization (Web Worker)
-    ↓
+                ↓
 Output Display → Copy/Download
 ```
 
-## 🎨 Design Patterns
+## Design Patterns
 
 ### 1. Provider Pattern
 
@@ -451,78 +385,75 @@ class ErrorBoundary extends Component {
 )}
 ```
 
-## 📁 Project Structure
+## Project Structure
 
 ```
 repo2txt/
-├── .githooks/
-│   └── pre-commit            # Runs act CI before each commit
 ├── .github/
 │   └── workflows/
-│       ├── ci.yml              # CI checks (act-compatible, local only)
 │       └── deploy.yml          # GitHub Pages deployment
 │
 ├── src/
-│   ├── features/                # Feature modules (domain-driven)
+│   ├── features/               # Feature modules (domain-driven)
 │   │   ├── github/
-│   │   │   ├── GitHubProvider.ts      # GitHub API implementation
-│   │   │   ├── components/            # GitHub-specific UI
-│   │   │   │   ├── GitHubAuth.tsx    # Token management
-│   │   │   │   ├── GitHubForm.tsx    # URL input form
+│   │   │   ├── GitHubProvider.ts
+│   │   │   ├── components/
+│   │   │   │   ├── GitHubAuth.tsx
+│   │   │   │   ├── GitHubForm.tsx
 │   │   │   │   └── GitHubUrlInput.tsx
-│   │   │   └── __tests__/            # Feature tests
+│   │   │   └── __tests__/
 │   │   │
 │   │   ├── local/
-│   │   │   ├── LocalProvider.ts       # File System API
+│   │   │   ├── LocalProvider.ts
 │   │   │   └── components/
 │   │   │       ├── DirectoryPicker.tsx
 │   │   │       ├── ZipUploader.tsx
 │   │   │       └── LocalForm.tsx
 │   │   │
-│   │   ├── gitlab/                    # GitLab provider (beta)
-│   │   └── azure/                     # Azure DevOps (beta)
+│   │   ├── gitlab/             # GitLab provider (beta)
+│   │   └── azure/              # Azure DevOps (beta)
 │   │
-│   ├── components/              # Shared UI components
-│   │   ├── ui/                 # Base components (buttons, dialogs)
+│   ├── components/             # Shared UI components
+│   │   ├── ui/                 # Base components
 │   │   │   ├── Button.tsx
 │   │   │   ├── ErrorDialog.tsx
 │   │   │   └── ThemeToggle.tsx
 │   │   │
 │   │   ├── file-tree/          # File tree components
-│   │   │   ├── FileTree.tsx           # Virtual scrolling tree
-│   │   │   └── FileTreeNode.tsx       # Individual node
+│   │   │   ├── FileTree.tsx
+│   │   │   └── FileTreeNode.tsx
 │   │   │
 │   │   ├── filters/            # Filtering components
 │   │   │   ├── AdvancedFilters.tsx
 │   │   │   ├── ExtensionFilter.tsx
 │   │   │   └── GitignoreEditor.tsx
 │   │   │
-│   │   ├── OutputPanel.tsx     # Output display & actions
-│   │   ├── FileStats.tsx       # Token/line statistics
-│   │   └── ProviderSelector.tsx # Provider tabs
+│   │   ├── OutputPanel.tsx
+│   │   ├── FileStats.tsx
+│   │   └── ProviderSelector.tsx
 │   │
 │   ├── lib/                    # Core business logic
 │   │   ├── providers/
-│   │   │   ├── BaseProvider.ts        # Abstract base class
-│   │   │   └── types.ts              # Shared provider types
+│   │   │   ├── BaseProvider.ts
+│   │   │   └── types.ts
 │   │   │
 │   │   ├── formatter/
-│   │   │   ├── Formatter.ts          # Output formatting
-│   │   │   ├── TokenizerWorker.ts    # Web Worker wrapper
+│   │   │   ├── Formatter.ts
+│   │   │   ├── TokenizerWorker.ts
 │   │   │   └── __tests__/
 │   │   │
 │   │   ├── gitignore/
-│   │   │   └── GitignoreParser.ts    # .gitignore parsing
+│   │   │   └── GitignoreParser.ts
 │   │   │
-│   │   └── utils.ts            # Shared utilities
+│   │   └── utils.ts
 │   │
 │   ├── store/                  # Zustand state management
-│   │   ├── index.ts            # Store composition
-│   │   └── slices/             # Store slices
-│   │       ├── providerSlice.ts      # Provider state
-│   │       ├── fileTreeSlice.ts      # File tree state
-│   │       ├── filterSlice.ts        # Filter state
-│   │       └── uiSlice.ts            # UI state (theme, loading)
+│   │   ├── index.ts
+│   │   └── slices/
+│   │       ├── providerSlice.ts
+│   │       ├── fileTreeSlice.ts
+│   │       ├── filterSlice.ts
+│   │       └── uiSlice.ts
 │   │
 │   ├── hooks/                  # Custom React hooks
 │   │   ├── useFileTree.ts
@@ -530,14 +461,14 @@ repo2txt/
 │   │   └── useTheme.ts
 │   │
 │   ├── workers/                # Web Workers
-│   │   └── tokenizer.worker.ts       # GPT tokenizer
+│   │   └── tokenizer.worker.ts
 │   │
 │   ├── types/                  # Shared TypeScript types
 │   │   └── index.ts
 │   │
-│   ├── App.tsx                 # Root component
-│   ├── main.tsx               # Entry point
-│   └── index.css              # Global styles
+│   ├── App.tsx
+│   ├── main.tsx
+│   └── index.css
 │
 ├── tests/
 │   ├── e2e/                    # End-to-end tests (Playwright)
@@ -552,13 +483,13 @@ repo2txt/
 ├── public/                     # Static assets
 ├── dist/                       # Build output (git-ignored)
 │
-├── .eslintrc.cjs              # ESLint configuration
-├── .prettierrc                # Prettier configuration
-├── tsconfig.json              # TypeScript configuration
-├── vite.config.ts             # Vite configuration
-├── playwright.config.ts       # Playwright configuration
-├── vitest.config.ts           # Vitest configuration
-└── package.json               # Dependencies & scripts
+├── .eslintrc.cjs
+├── .prettierrc
+├── tsconfig.json
+├── vite.config.ts
+├── playwright.config.ts
+├── vitest.config.ts
+└── package.json
 ```
 
 ### Key Directories Explained
@@ -573,18 +504,18 @@ repo2txt/
 
 **`workers/`** - Web Workers for CPU-intensive tasks. Keeps UI thread responsive.
 
-## 🧪 Testing Strategy
+## Testing Strategy
 
 ### Testing Pyramid
 
 ```
-       /\
-      /  \     E2E (Playwright)      - 25 tests
-     /____\    Critical user flows
-    /      \
-   /        \  Integration            - Provider + UI
-  /__________\
- /            \ Unit (Vitest)         - 80%+ coverage
+    /\
+   /  \     E2E (Playwright) - 25 tests
+  /____\    Critical user flows
+ /      \
+/        \  Integration - Provider + UI
+/__________\
+/          \  Unit (Vitest) - 80%+ coverage
 /______________\ Business logic, utilities, components
 ```
 
@@ -610,8 +541,8 @@ describe('Formatter', () => {
 
     const formatted = Formatter.formatTree(tree);
 
-    expect(formatted).toContain('├── 📁 src');
-    expect(formatted).toContain('└── 📄 index.ts');
+    expect(formatted).toContain('├── src');
+    expect(formatted).toContain('└── index.ts');
   });
 
   it('should count tokens accurately', () => {
@@ -655,10 +586,10 @@ describe('GitHub Provider Integration', () => {
 
 **Current Coverage:**
 
-- ✅ Dark mode (5 tests)
-- ✅ Error scenarios (8 tests)
-- ✅ GitHub flow (6 tests)
-- ✅ Local flow (6 tests)
+- Dark mode (5 tests)
+- Error scenarios (8 tests)
+- GitHub flow (6 tests)
+- Local flow (6 tests)
 
 **Example:**
 
@@ -697,14 +628,14 @@ test('should complete full GitHub public repo flow', async ({ page }) => {
 
 ```bash
 # Unit tests
-bun run test:unit              # Run once
-bun run test:watch             # Watch mode
-bun run test:coverage          # With coverage
+bun run test:unit    # Run once
+bun run test:watch   # Watch mode
+bun run test:coverage # With coverage
 
 # E2E tests
-bun run test:e2e              # All browsers
+bun run test:e2e                    # All browsers
 bun run test:e2e -- --project=chromium  # Single browser
-bun run test:e2e:ui           # Interactive UI
+bun run test:e2e:ui                 # Interactive UI
 
 # Test specific file
 bun run test:unit -- Formatter.test.ts
@@ -729,7 +660,7 @@ export const testConfig = {
 
 Tests run automatically on PRs via GitHub Actions. Set `GITHUB_TOKEN` secret in repository settings for E2E tests.
 
-## 💅 Code Style
+## Code Style
 
 ### TypeScript
 
@@ -741,7 +672,7 @@ Tests run automatically on PRs via GitHub Actions. Set `GITHUB_TOKEN` secret in 
 **Example:**
 
 ```typescript
-// ✅ Good
+// Good
 interface FileNode {
   path: string;
   type: 'blob' | 'tree';
@@ -755,7 +686,7 @@ function filterNodes(nodes: FileNode[], predicate: (node: FileNode) => boolean):
   }));
 }
 
-// ❌ Bad
+// Bad
 function filterNodes(nodes: any, predicate): any {
   return nodes.filter(predicate);
 }
@@ -771,7 +702,7 @@ function filterNodes(nodes: any, predicate): any {
 **Example:**
 
 ```typescript
-// ✅ Good
+// Good
 interface FileTreeNodeProps {
   node: TreeNode;
   depth: number;
@@ -786,7 +717,7 @@ export function FileTreeNode({ node, depth, onToggle }: FileTreeNodeProps) {
   return (
     <div style={{ paddingLeft: `${depth * 16}px` }}>
       <button onClick={() => onToggle(node.path)}>
-        {isDirectory ? '📁' : '📄'} {node.name}
+        {isDirectory ? 'Folder' : 'File'} {node.name}
       </button>
     </div>
   );
@@ -803,14 +734,14 @@ export function FileTreeNode({ node, depth, onToggle }: FileTreeNodeProps) {
 **Example:**
 
 ```tsx
-// ✅ Good
+// Good
 <div className="flex items-center gap-2 p-4 bg-white dark:bg-gray-900 rounded-lg">
   <button className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-md transition-colors">
     Click me
   </button>
 </div>
 
-// ❌ Bad
+// Bad
 <div style={{ display: 'flex', padding: '16px', backgroundColor: '#fff' }}>
   <button style={{ padding: '8px 16px', backgroundColor: '#3b82f6' }}>
     Click me
@@ -859,7 +790,7 @@ bun run format        # Format with Prettier
 bun run format:check  # Check formatting
 ```
 
-## 🔄 Development Workflow
+## Development Workflow
 
 ### Branch Strategy
 
@@ -918,8 +849,8 @@ git commit -m "docs: update architecture documentation"
 3. **Test Locally**
 
    ```bash
-   bun run ci          # Type check + lint + unit tests
-   bun run test:e2e    # E2E tests
+   bun run ci       # Type check + lint + unit tests
+   bun run test:e2e # E2E tests
    ```
 
 4. **Commit Changes**
@@ -966,7 +897,7 @@ Before submitting a PR:
 - [ ] No console.logs or debugger statements
 - [ ] Bundle size impact is acceptable
 
-## 🐛 Debugging Tips
+## Debugging Tips
 
 ### React DevTools
 
@@ -1009,7 +940,7 @@ DEBUG=vite:* bun run dev
 - Check worker file path in Vite config
 - Ensure worker is imported with `?worker` suffix
 
-## 📚 Additional Resources
+## Additional Resources
 
 - [React Documentation](https://react.dev/)
 - [TypeScript Handbook](https://www.typescriptlang.org/docs/)
@@ -1018,7 +949,7 @@ DEBUG=vite:* bun run dev
 - [Tailwind CSS](https://tailwindcss.com/docs)
 - [Playwright Documentation](https://playwright.dev/)
 
-## 💬 Questions?
+## Questions?
 
 - **GitHub Discussions**: [Ask questions](https://github.com/michael-farah/repo2txt-extension/discussions)
 - **Issues**: [Report bugs](https://github.com/michael-farah/repo2txt-extension/issues)
@@ -1026,4 +957,4 @@ DEBUG=vite:* bun run dev
 
 ---
 
-Thank you for contributing to repo2txt! 🎉
+Thank you for contributing to repo2txt!

--- a/README.md
+++ b/README.md
@@ -1,55 +1,55 @@
-# repo2txt — Chrome Extension
+# repo2txt - Chrome Extension
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > **Convert GitHub repositories and local folders to plain text for LLM prompts**
-> Fast, privacy-first Chrome extension for AI-assisted development
+> Privacy-first Chrome extension for AI-assisted development
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
-This Chrome extension is a fork of [repo2txt](https://github.com/abinthomasonline/repo2txt) by [Abin Thomas](https://github.com/abinthomasonline). The original web version is available at [abinthomas.in/repo2txt](https://abinthomas.in/repo2txt/). Full credit for the core architecture, provider system, and UI design goes to the original project.
+This extension forks [repo2txt](https://github.com/abinthomasonline/repo2txt) by [Abin Thomas](https://github.com/abinthomasonline). The original web version lives at [abinthomas.in/repo2txt](https://abinthomas.in/repo2txt/). Core architecture, provider system, and UI design come from the original project.
 
-## ✨ Features
+## Features
 
-### 🔌 Multiple Sources
+### Multiple Sources
 
-- **GitHub** - Public and private repositories with token support
-- **Local Files** - Directory picker for your local projects
-- **Zip Upload** - Drag & drop zip files
+- **GitHub**: Public and private repositories with token support
+- **Local Files**: Directory picker for your local projects
+- **Zip Upload**: Drag and drop zip files
 
-### 🎯 Smart Filtering
+### Smart Filtering
 
-- **Extension Filter** - Select/deselect by file type
-- **Gitignore Support** - Automatically respect .gitignore patterns
-- **Custom Patterns** - Add your own ignore patterns
-- **Directory Selection** - Cherry-pick specific folders
-- **File Tree Preview** - Visual file selection with virtual scrolling
+- **Extension Filter**: Select and deselect by file type
+- **Gitignore Support**: Respects .gitignore patterns automatically
+- **Custom Patterns**: Add your own ignore patterns
+- **Directory Selection**: Cherry-pick specific folders
+- **File Tree Preview**: Visual file selection with virtual scrolling
 
-### 🚀 Performance
+### Performance
 
-- **Virtual Scrolling** - Handle repositories with 10,000+ files
-- **Code Splitting** - Lazy-loaded providers for optimal bundle size
-- **Web Workers** - Tokenization runs in background threads
-- **Progressive Loading** - Stream file contents as they load
-- **Smart Caching** - Efficient memory usage for large repos
+- **Virtual Scrolling**: Handles repositories with 10,000+ files
+- **Code Splitting**: Lazy-loaded providers for optimal bundle size
+- **Web Workers**: Tokenization runs in background threads
+- **Progressive Loading**: Streams file contents as they load
+- **Smart Caching**: Efficient memory usage for large repos
 
-### 🎨 Modern UX
+### Modern UX
 
-- **Dark Mode** - System, light, and dark themes
-- **Responsive Design** - Works on desktop, tablet, and mobile
-- **Token Counter** - Real-time GPT token counting
-- **File Statistics** - Per-file token and line counts
-- **Progress Indicators** - Clear feedback during loading
-- **GitHub Integration** - "Convert to Text" button on GitHub repo pages
+- **Dark Mode**: System, light, and dark themes
+- **Responsive Design**: Works on desktop, tablet, and mobile
+- **Token Counter**: Real-time GPT token counting
+- **File Statistics**: Per-file token and line counts
+- **Progress Indicators**: Clear feedback during loading
+- **GitHub Integration**: "Convert to Text" button on GitHub repo pages
 
-### 🔒 Privacy First
+### Privacy First
 
-- **100% Client-Side** - No server uploads, all processing is local
-- **No Tracking** - Your code never leaves your device
-- **Encrypted Storage** - GitHub tokens encrypted with per-install keys
-- **Open Source** - Fully auditable codebase
+- **100% Client-Side**: No server uploads, all processing is local
+- **No Tracking**: Your code never leaves your device
+- **Encrypted Storage**: GitHub tokens encrypted with per-install keys
+- **Open Source**: Fully auditable codebase
 
-## 🚀 Install
+## Install
 
 ### From Source
 
@@ -68,7 +68,7 @@ Then load the `dist/` folder as an unpacked extension in `chrome://extensions`.
 bun run build:crx
 ```
 
-This creates `release/repo2txt-v{version}.zip` ready for Chrome Web Store upload.
+This creates `release/repo2txt-v{version}.zip` for Chrome Web Store upload and `release/repo2txt-v{version}.crx` for self-hosted distribution.
 
 ### Development
 
@@ -79,7 +79,7 @@ bun run dev
 
 Open `http://localhost:5173` in your browser.
 
-## 📖 Usage
+## Usage
 
 ### GitHub Repository
 
@@ -93,7 +93,7 @@ Open `http://localhost:5173` in your browser.
 6. Click "Generate"
 7. Copy to clipboard or download as `.txt`
 
-**Or**: Visit any GitHub repo page and click the "Convert to Text" button injected into the page header.
+You can also visit any GitHub repo page and click the "Convert to Text" button injected into the page header.
 
 **Supported URL formats:**
 
@@ -109,7 +109,7 @@ Open `http://localhost:5173` in your browser.
 3. Select your project folder or upload a zip
 4. Same filtering and export options as GitHub
 
-## 🛠️ Tech Stack
+## Tech Stack
 
 - **Framework**: React 19 + TypeScript
 - **Build Tool**: Vite 5
@@ -120,9 +120,9 @@ Open `http://localhost:5173` in your browser.
 - **Virtual Scrolling**: TanStack Virtual
 - **Testing**: Vitest + Playwright
 
-## 🤝 Contributing
+## Contributing
 
-Contributions welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development guide and architecture details.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the development guide and architecture details.
 
 ```bash
 git clone https://github.com/michael-farah/repo2txt-extension.git
@@ -134,7 +134,7 @@ bun run dev
 
 ## Browser Support
 
-**Chrome Only** — This extension uses Chrome Manifest V3 APIs including service workers and `chrome.storage.local`.
+**Chrome Only.** This extension uses Chrome Manifest V3 APIs including service workers and `chrome.storage.local`.
 
 ### Future Support
 
@@ -142,11 +142,11 @@ bun run dev
 - **Safari**: Requires Xcode project generation and App Store distribution
 - **Edge**: Should work as-is since Edge supports Chrome extensions
 
-Contributions for cross-browser support are welcome!
+Contributions for cross-browser support are welcome.
 
 ## Future Providers
 
-We're considering support for additional Git hosting platforms:
+Support for additional Git hosting platforms is under consideration:
 
 - **GitLab**: API authentication, self-hosted instances, different rate limits
 - **Bitbucket**: API authentication, different repository structure
@@ -154,11 +154,11 @@ We're considering support for additional Git hosting platforms:
 
 To contribute a new provider, extend `BaseProvider` and implement `fetchTree`, `fetchFile`, `validateUrl`, and `parseUrl`. See `src/features/github/GitHubProvider.ts` for reference.
 
-## 📝 License
+## License
 
-MIT License - see [LICENSE](./LICENSE) for details
+MIT License. See [LICENSE](./LICENSE) for details.
 
-## 🔗 Links
+## Links
 
 - **Repository**: [github.com/michael-farah/repo2txt-extension](https://github.com/michael-farah/repo2txt-extension)
 - **Original Web Version**: [github.com/abinthomasonline/repo2txt](https://github.com/abinthomasonline/repo2txt)

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "@vitejs/plugin-react": "^4.7.0",
         "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.24",
+        "crx3": "^2.0.0",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -448,7 +449,7 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
-    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
+    "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -487,6 +488,8 @@
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "crx3": ["crx3@2.0.0", "", { "dependencies": { "mri": "^1.2.0", "pbf": "^4.0.1", "yazl": "^3.3.1" }, "bin": { "crx3": "bin/crx3.js" } }, "sha512-f23Oi2Zpl68aBSf5gHwn+lxQyPF+m2NAhMwwycXOxqOx6bpzDqzbcp6k/DRsyHxpsDvg5WwXcHOJSOgJ7Px5LQ=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
@@ -752,6 +755,8 @@
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msw": ["msw@2.13.3", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.11.7", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w=="],
@@ -806,6 +811,8 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "pbf": ["pbf@4.0.1", "", { "dependencies": { "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA=="],
+
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -844,6 +851,8 @@
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
+    "protocol-buffers-schema": ["protocol-buffers-schema@3.6.1", "", {}, "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ=="],
+
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -879,6 +888,8 @@
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "resolve-protobuf-schema": ["resolve-protobuf-schema@2.1.0", "", { "dependencies": { "protocol-buffers-schema": "^3.3.1" } }, "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ=="],
 
     "rettime": ["rettime@0.11.7", "", {}, "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg=="],
 
@@ -1032,6 +1043,8 @@
 
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
+    "yazl": ["yazl@3.3.1", "", { "dependencies": { "buffer-crc32": "^1.0.0" } }, "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng=="],
+
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
@@ -1087,6 +1100,8 @@
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.15", "", {}, "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g=="],
 
     "vitest/vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
+
+    "yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.24",
+    "crx3": "^2.0.0",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/scripts/package-crx.ts
+++ b/scripts/package-crx.ts
@@ -1,6 +1,10 @@
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, createReadStream } from 'fs';
 import { resolve } from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const crx3 = require('crx3');
 
 const distDir = resolve(import.meta.dir, '../dist');
 const releaseDir = resolve(import.meta.dir, '../release');
@@ -25,8 +29,22 @@ console.log(`Packaging repo2txt v${version}...`);
 
 // Create zip for Chrome Web Store
 const zipName = `repo2txt-v${version}.zip`;
-execSync(`cd ${distDir} && zip -r ${resolve(releaseDir, zipName)} . -x "*.map"`);
+const zipPath = resolve(releaseDir, zipName);
+execSync(`cd ${distDir} && zip -r ${zipPath} . -x "*.map"`);
 
-console.log(`Created: release/${zipName}`);
-console.log('\nUpload this zip to Chrome Web Store Developer Dashboard.');
-console.log('For local testing, load the dist/ folder as an unpacked extension.');
+// Create CRX for self-hosted distribution
+const crxName = `repo2txt-v${version}.crx`;
+const crxPath = resolve(releaseDir, crxName);
+
+crx3(createReadStream(zipPath), { crxPath })
+  .then(() => {
+    console.log(`Created: release/${zipName}`);
+    console.log(`Created: release/${crxName}`);
+    console.log('\nUpload the zip to Chrome Web Store Developer Dashboard.');
+    console.log('Use the crx for self-hosted extension distribution.');
+    console.log('For local testing, load the dist/ folder as an unpacked extension.');
+  })
+  .catch((err: Error) => {
+    console.error('Failed to create CRX:', err.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Changes

- Clean up README and CONTRIBUTING
- Add CRX packaging for self-hosted distribution
- Ignore release/ build output

The packaging script now produces both .zip and .crx in release/. The existing CI workflow already uploads release/* to GitHub Releases on version tags.