### PR TITLE
fix(ci): attach release artifacts and remove insecure CSP blob

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,22 +52,24 @@ jobs:
           path: release/
           retention-days: 30
 
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+release:
+  runs-on: ubuntu-latest
+  needs: build
+  if: startsWith(github.ref, 'refs/tags/v')
+  permissions:
+    contents: write
+  steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: repo2txt-extension
+        path: release
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: repo2txt-extension
-          path: release/
+    - name: List release files
+      run: ls -laR release/
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: release/*
-          generate_release_notes: true
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: release/repo2txt-extension/*
+        generate_release_notes: true

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -47,6 +47,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self' blob: data:"
+  "extension_pages": "script-src 'self'; object-src 'self'"
   }
 }


### PR DESCRIPTION
download-artifact@v4 nests files under <artifact-name>/ subdirectory, so the release glob must match release/repo2txt-extension/*, not release/*. Removed unnecessary checkout step and added job-level permissions + debug listing.

Chrome MV3 rejects blob: in object-src directive. Extension doesn't use <object>/<embed> tags, so removing blob: data: has no functional impact.