### PR TITLE
fix(ci): allow release on workflow_dispatch and upgrade actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -46,7 +46,7 @@ jobs:
         run: bun run scripts/package-crx.ts
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: repo2txt-extension
           path: release/
@@ -55,12 +55,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: repo2txt-extension
           path: release
@@ -69,7 +69,7 @@ jobs:
         run: ls -laR release/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: release/repo2txt-extension/*
           generate_release_notes: true


### PR DESCRIPTION
Release job skipped on non-tag triggers because the if-condition only matched refs/tags/v. Added workflow_dispatch as an OR condition so manual runs also create releases.

Upgraded actions to Node 24 compatible versions:
- actions/checkout v4 → v6
- actions/upload-artifact v4 → v7
- actions/download-artifact v4 → v8
- softprops/action-gh-release v2 → v3